### PR TITLE
[#7] Styling text-image

### DIFF
--- a/wp-content/themes/wp-starter/blocks/text-image/block.json
+++ b/wp-content/themes/wp-starter/blocks/text-image/block.json
@@ -10,6 +10,19 @@
     "align": {
       "type": "string",
       "default": "wide"
+    },
+    "style": {
+      "type": "object",
+      "default": {
+        "spacing": {
+          "padding": {
+            "top": "var:preset|spacing|20",
+            "bottom": "var:preset|spacing|20",
+            "left": "var:preset|spacing|20",
+            "right": "var:preset|spacing|20"
+          }
+        }
+      }
     }
   },
   "supports": {

--- a/wp-content/themes/wp-starter/src/styles/blocks/logo-grid.css
+++ b/wp-content/themes/wp-starter/src/styles/blocks/logo-grid.css
@@ -2,12 +2,12 @@
 	.acf-block-logo-grid {
 		& figure {
 			@apply flex;
-			@apply aspect-grid-image;
+			@apply aspect-5/3;
 			@apply basis-1/2-gap lg:basis-1/4-gap;
 
 			& img {
 				@apply block;
-				@apply max-w-full h-full;
+				@apply h-full max-w-full;
 				@apply object-contain;
 			}
 		}

--- a/wp-content/themes/wp-starter/src/styles/blocks/text-image.css
+++ b/wp-content/themes/wp-starter/src/styles/blocks/text-image.css
@@ -1,0 +1,22 @@
+@layer components {
+	.acf-block-text-image {
+		.wp-block-media-text {
+			@apply gap-fluid-sm;
+		}
+		.wp-block-media-text__media {
+			@apply aspect-5/4 w-full;
+		}
+
+		.wp-block-media-text__content {
+			@apply flex flex-col items-start gap-16 p-0;
+
+			.is-style-eyebrow {
+				@apply m-0 text-sm font-bold uppercase tracking-tighter;
+			}
+
+			.wp-block-heading {
+				@apply m-0 text-lg font-bold leading-tight;
+			}
+		}
+	}
+}

--- a/wp-content/themes/wp-starter/src/styles/main.css
+++ b/wp-content/themes/wp-starter/src/styles/main.css
@@ -10,3 +10,4 @@
 @import './blocks/cta.css';
 @import './blocks/accordion.css';
 @import './blocks/logo-grid.css';
+@import './blocks/text-image.css';

--- a/wp-content/themes/wp-starter/src/theme-json/settings/spacing.js
+++ b/wp-content/themes/wp-starter/src/theme-json/settings/spacing.js
@@ -7,32 +7,32 @@ export default {
 	spacingSizes: [
 		{
 			name: '1',
-			size: theme.spacing.one,
+			size: theme.spacing['fluid-xs'],
 			slug: '10',
 		},
 		{
 			name: '2',
-			size: theme.spacing.two,
+			size: theme.spacing['fluid-sm'],
 			slug: '20',
 		},
 		{
 			name: '3',
-			size: theme.spacing.three,
+			size: theme.spacing['fluid-md'],
 			slug: '30',
 		},
 		{
 			name: '4',
-			size: theme.spacing.four,
+			size: theme.spacing['fluid-lg'],
 			slug: '40',
 		},
 		{
 			name: '5',
-			size: theme.spacing.five,
+			size: theme.spacing['fluid-xl'],
 			slug: '50',
 		},
 		{
 			name: '6',
-			size: theme.spacing.six,
+			size: theme.spacing['fluid-2xl'],
 			slug: '60',
 		},
 	],

--- a/wp-content/themes/wp-starter/tailwind.config.js
+++ b/wp-content/themes/wp-starter/tailwind.config.js
@@ -31,7 +31,8 @@ module.exports = {
 		contentBase: maxBreakpoint.toString(),
 		extend: {
 			aspectRatio: {
-				'grid-image': '5/3',
+				'5/3': '5/3',
+				'5/4': '5/4',
 			},
 			colors: {
 				transparent: 'transparent',
@@ -63,12 +64,12 @@ module.exports = {
 			},
 			spacing: {
 				// If you update the names or add more spacing you will need to update the file in theme-json/settings/spacing.js
-				one: fluidSize(2, 16),
-				two: fluidSize(20, 40),
-				three: fluidSize(32, 64),
-				four: fluidSize(56, 112),
-				five: fluidSize(96, 160),
-				six: fluidSize(144, 240),
+				"fluid-xs": fluidSize(2, 16),
+				"fluid-sm": fluidSize(20, 40),
+				"fluid-md": fluidSize(32, 64),
+				"fluid-lg": fluidSize(56, 112),
+				"fluid-xl": fluidSize(96, 160),
+				"fluid-2xl": fluidSize(144, 240),
 				//These are not pulled into WordPress theme.json
 				...remPair(0),
 				...remPair(1),


### PR DESCRIPTION
# Summary

Styling the component to match the design and BP. 

## Issues

* #7

## Testing Instructions

1. Add the text-image component to the page. 

## Screenshots
<img width="719" alt="Screenshot 2024-04-25 at 2 18 44 PM" src="https://github.com/vigetlabs/wordpress-site-starter/assets/91974372/36c3708f-28a5-4ddf-bb0f-f3f37337ef14">
<img width="337" alt="Screenshot 2024-04-25 at 2 19 05 PM" src="https://github.com/vigetlabs/wordpress-site-starter/assets/91974372/4e3b7691-b4da-475d-b878-9d02bd2f007d">

