### PR TITLE
[#53] Adding readme updates

### DIFF
--- a/README.dist.md
+++ b/README.dist.md
@@ -14,52 +14,34 @@ This is the README for your new site. Feel free to update any of this info to ma
 
 
 ## Setup and Running
+To start the local server and build process. 
 
-Run `ddev start` to start the site. This will install WordPress files, composer packages, npm packages, and start the DDEV server. Once the server is started DDEV will automatically start Vite for local development. 
+```bash
+ddev start
+```
 
-If this is the first time this project has been set up: 
+This will install WordPress files, composer packages, npm packages, and start the DDEV server. Once the server is started, DDEV will automatically start Vite for local development. 
+
+### New Project
+If this is the first time setting up this project, once the install is done the site will ask you to: 
 1. Select the desired language.
 2. Fill out the site information.
 3. Then click "Install WordPress"
 4. Once WordPress has been set up login with your user information.
 
-If this is an existing project, get an database download from production, staging or another team member. Steps to download a database are different depending on the hosting server. 
-
-Once you have the database file import the database into DDEV using:
-```bash
-ddev import-db --file=FILENAME.sql.gz
-```
-Then login using the username/password for the user on that database.
+### Existing Project
+If this is an existing project you can import the local database file then you are prompted. Then provide the path to the file to be imported.
 
 You are all ready to start working on the site.
 
 ### Build for production
-The deploy script should build the files for production, but if you want to test that out on your local server you can change the DDEV config.yaml `ENVIRONMENT` to `prod` and then run `ddev npm run build`. This will build the JS and CSS files in the dist folder and out put a manifest file.
-
-### Theme.json
-The `theme.json` holds a lot of the core WordPress theme settings. The `theme.json` is build using several js files in `/src/theme-json`, Vite builds all of these files and exports a `theme.json` for both `dev` and `build`. Do not edit directly `theme.json` as it will be over written on build. 
-
-Several of the Tailwind variables are pulled in and Tailwind should be used as the primary way to style elements. If you need to, you can pull in more Tailwind variable for custom styling in `theme.json`.
+The deploy script should build the files for production, but if you want to test that out on your local server you can change the DDEV config.yaml `ENVIRONMENT` to `prod` and then `cd` into your custom theme folder and run `ddev npm run build`. This will build the JS and CSS files in the dist folder and out put a manifest file.
 
 ## Plugins
 * [Advanced Custom Fields PRO](https://www.advancedcustomfields.com/pro/)
 * *List other Plugins used*
 
-## Custom Blocks
-Builds are build using ACF and core WordPress blocks. Styles for the blocks are in `src/styles/blocks`.
-
-* Accordion
-* Alert Banner
-* CTA
-* Image Caption
-* Logo Grid
-* Text Icon Cards
-* Text Image
-* Video Embed
-* *List other custom Blocks*
-
 ## Commands
-
 ```bash
 ddev start
 ddev rebuild

--- a/README.dist.md
+++ b/README.dist.md
@@ -1,46 +1,71 @@
 # WordPress Site Starter
-To use this, clone the WordPress Site Starter into the new project repo. Update this to have info about things to note how to be successful using the starter.
+This is the README for your new site. Feel free to update any of this info to match your project. 
+
+## Links
+-   [Production](#UPDATETHIS)
+-   [Staging](#UPDATETHIS)
+-   [Development](#UPDATETHIS)
 
 ## Requirements
 * [Composer](https://getcomposer.org/) - [Installation](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos)
 * [DDEV](https://ddev.readthedocs.io/en/stable/) - [Installation](https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/)
-* [Docker](https://docs.docker.com/desktop/install/mac-install/) (or compatible container alternative)
+* [Docker](https://docs.docker.com/desktop/install/mac-install/) (or compatible container alternative like  OrbStack)
 * For ACF Pro, create an `auth.json` file in `wp-content/mu-plugins/viget-base/` from the [ACF Website](https://www.advancedcustomfields.com/my-account/view-licenses/). (Credentials are in 1Password)
+
 
 ## Setup and Running
 
-Download and install WordPress core files if this is the first time running DDEV
-`ddev wp core download`
+Run `ddev start` to start the site. This will install WordPress files, composer packages, npm packages, and start the DDEV server. Once the server is started DDEV will automatically start Vite for local development. 
 
-Start local developement server
-`bin/start`
+If this is the first time this project has been set up: 
+1. Select English as the language.
+2. Fill out the site information.
+3. Then click "Install WordPress"
+4. Once WordPress has been set up login with your user information.
 
-1. Open a browser and navigate to [local site](https://wpstarter.ddev.site).
-2. Select English as the language.
-3. Fill out the site information.
-4. Then click "Install WordPress"
-5. Once WordPress has been set up login with your user information.
+If this is an existing project, get an database download from production, staging or another team member. Steps to download a database are different depending on the hosting server. 
 
-If you need to build production files. Change the DDEV config.yaml `ENVIRONMENT`
-to `prod` and then run `bin/build`. Which will build the JS and CSS files in the dist folder and out put a manifest file.
+Once you have the database file import the database into DDEV using:
+```bash
+ddev import-db --file=FILENAME.sql.gz
+```
+Then login using the username/password for the user on that database.
+
+You are all ready to start working on the site.
+
+### Build for production
+The deploy script should build the files for production, but if you want to test that out on your local server you can change the DDEV config.yaml `ENVIRONMENT` to `prod` and then run `ddev npm run build`. This will build the JS and CSS files in the dist folder and out put a manifest file.
+
+### Theme.json
+The `theme.json` holds a lot of the core WordPress theme settings. The `theme.json` is build using several js files in `/src/theme-json`, Vite builds all of these files and exports a `theme.json` for both `dev` and `build`. Do not edit directly `theme.json` as it will be over written on build. 
+
+Several of the Tailwind variables are pulled in and Tailwind should be used as the primary way to style elements. If you need to, you can pull in more Tailwind variable for custom styling in `theme.json`.
+
+## Plugins
+* [Advanced Custom Fields PRO](https://www.advancedcustomfields.com/pro/)
+* *List other Plugins used*
 
 ## Blocks
 Builds are build using ACF and core WordPress blocks. Styles for the blocks are in `src/styles/blocks`.
 
-- Accordion
-- Alert Banner
-- CTA
-- Image Caption
-- Logo Grid
-- Text Icon Cards
-- Text Image
-- Video Embed
+* Accordion
+* Alert Banner
+* CTA
+* Image Caption
+* Logo Grid
+* Text Icon Cards
+* Text Image
+* Video Embed
+* *List other custom Blocks*
 
 ## Commands
 
-```
-ddev npm run dev #builds local files
-ddev npm run build  #builds production files
+```bash
+ddev start
+ddev rebuild
+ddev stop
+ddev npm run dev #builds local
+ddev npm run build  #builds production
 ```
 
 In order to run Vite you need to run it inside of DDEV by running `ddev npm run dev` inside of your theme folder.

--- a/README.dist.md
+++ b/README.dist.md
@@ -9,7 +9,7 @@ This is the README for your new site. Feel free to update any of this info to ma
 ## Requirements
 * [Composer](https://getcomposer.org/) - [Installation](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos)
 * [DDEV](https://ddev.readthedocs.io/en/stable/) - [Installation](https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/)
-* [Docker](https://docs.docker.com/desktop/install/mac-install/) (or compatible container alternative like  OrbStack)
+* [Docker](https://docs.docker.com/desktop/install/mac-install/) (or compatible container alternative like OrbStack)
 * For ACF Pro, create an `auth.json` file in `wp-content/mu-plugins/viget-base/` from the [ACF Website](https://www.advancedcustomfields.com/my-account/view-licenses/). (Credentials are in 1Password)
 
 
@@ -20,7 +20,7 @@ To start the local server and build process, run:
 ddev start
 ```
 
-This will install the WordPress files, composer packages, npm packages, and start the DDEV server. Once the server is started, DDEV will automatically start Vite for local development. 
+This will install the WordPress files, composer packages, npm packages, and start the DDEV server. You will also be ask if you want to import a database or start with a new install. Once the server is started, DDEV will automatically start Vite for local development. 
 
 You are all ready to start working on the site.
 
@@ -32,7 +32,7 @@ The deploy script should build the files for production, but if you want to test
 * *List other Plugins used*
 
 ## Commands
-The command `ddev start` will automatically start Vite so you should not need to use any of the other `npm` commands. 
+The command `ddev start` will automatically start Vite so you should not need to use any `npm` commands. 
 
 ```bash
 ddev start

--- a/README.dist.md
+++ b/README.dist.md
@@ -18,7 +18,7 @@ This is the README for your new site. Feel free to update any of this info to ma
 Run `ddev start` to start the site. This will install WordPress files, composer packages, npm packages, and start the DDEV server. Once the server is started DDEV will automatically start Vite for local development. 
 
 If this is the first time this project has been set up: 
-1. Select English as the language.
+1. Select the desired language.
 2. Fill out the site information.
 3. Then click "Install WordPress"
 4. Once WordPress has been set up login with your user information.
@@ -45,7 +45,7 @@ Several of the Tailwind variables are pulled in and Tailwind should be used as t
 * [Advanced Custom Fields PRO](https://www.advancedcustomfields.com/pro/)
 * *List other Plugins used*
 
-## Blocks
+## Custom Blocks
 Builds are build using ACF and core WordPress blocks. Styles for the blocks are in `src/styles/blocks`.
 
 * Accordion

--- a/README.dist.md
+++ b/README.dist.md
@@ -14,23 +14,13 @@ This is the README for your new site. Feel free to update any of this info to ma
 
 
 ## Setup and Running
-To start the local server and build process. 
+To start the local server and build process, run: 
 
 ```bash
 ddev start
 ```
 
-This will install WordPress files, composer packages, npm packages, and start the DDEV server. Once the server is started, DDEV will automatically start Vite for local development. 
-
-### New Project
-If this is the first time setting up this project, once the install is done the site will ask you to: 
-1. Select the desired language.
-2. Fill out the site information.
-3. Then click "Install WordPress"
-4. Once WordPress has been set up login with your user information.
-
-### Existing Project
-If this is an existing project you can import the local database file then you are prompted. Then provide the path to the file to be imported.
+This will install the WordPress files, composer packages, npm packages, and start the DDEV server. Once the server is started, DDEV will automatically start Vite for local development. 
 
 You are all ready to start working on the site.
 
@@ -42,12 +32,11 @@ The deploy script should build the files for production, but if you want to test
 * *List other Plugins used*
 
 ## Commands
+The command `ddev start` will automatically start Vite so you should not need to use any of the other `npm` commands. 
+
 ```bash
 ddev start
 ddev rebuild
 ddev stop
-ddev npm run dev #builds local
-ddev npm run build  #builds production
 ```
-
-In order to run Vite you need to run it inside of DDEV by running `ddev npm run dev` inside of your theme folder.
+If you do need to run `npm` to troubleshoot something, you need to run it inside of DDEV by running `ddev npm run dev` inside of your custom theme folder.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a WordPress starter project that includes a basic custom theme, includin
 ## Requirements
 * [Composer](https://getcomposer.org/) - [Installation](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos)
 * [DDEV](https://ddev.readthedocs.io/en/stable/) - [Installation](https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/)
-* [Docker](https://docs.docker.com/desktop/install/mac-install/) (or compatible container alternative)
+* [Docker](https://docs.docker.com/desktop/install/mac-install/) (or compatible container alternative like OrbStack)
 * For ACF Pro, create an `auth.json` file in the project root directory, which can be downloaded from the [ACF Website](https://www.advancedcustomfields.com/my-account/view-licenses/).
 
 ## Using this Project
@@ -54,6 +54,12 @@ You can quickly remove the project by using:
 ```bash
 $ ddev delete project-name -O -y && cd ../ && rm -rf project-name
 ```
+
+## Theme.json
+The `theme.json` holds a lot of the core WordPress theme settings. The `theme.json` is build using several js files in `/src/theme-json`, Vite builds all of these files and exports a `theme.json` for both `dev` and `build`. Do not edit directly `theme.json` as it will be over written on build. 
+
+Several of the Tailwind variables are pulled in and Tailwind should be used as the primary way to style elements. If you need to, you can pull in more Tailwind variable for custom styling in `theme.json`.
+
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -55,12 +55,6 @@ You can quickly remove the project by using:
 $ ddev delete project-name -O -y && cd ../ && rm -rf project-name
 ```
 
-## Theme.json
-The `theme.json` holds a lot of the core WordPress theme settings. The `theme.json` is build using several js files in `/src/theme-json`, Vite builds all of these files and exports a `theme.json` for both `dev` and `build`. Do not edit directly `theme.json` as it will be over written on build. 
-
-Several of the Tailwind variables are pulled in and Tailwind should be used as the primary way to style elements. If you need to, you can pull in more Tailwind variable for custom styling in `theme.json`.
-
-
 ## Changelog
 
 ### v1.0.3

--- a/wp-content/themes/wp-starter/README.md
+++ b/wp-content/themes/wp-starter/README.md
@@ -8,7 +8,7 @@ The `theme.json` holds a lot of the core WordPress theme settings. The `theme.js
 Several of the Tailwind variables are pulled in and Tailwind should be used as the primary way to style elements. If you need to, you can pull in more Tailwind variable for custom styling in `theme.json`.
 
 ## Custom Blocks
-Builds are build using ACF and core WordPress blocks. Styles for the blocks are in `src/styles/blocks`.
+Blocks are build using ACF and core WordPress blocks. Styles for the blocks are in `src/styles/blocks`.
 
 * Accordion
 * Alert Banner

--- a/wp-content/themes/wp-starter/README.md
+++ b/wp-content/themes/wp-starter/README.md
@@ -1,3 +1,21 @@
 # WP Site Starter
 
 Custom block theme built by Viget.
+
+## Theme.json
+The `theme.json` holds a lot of the core WordPress theme settings. The `theme.json` is build using several js files in `/src/theme-json`, Vite builds all of these files and exports a `theme.json` for both `dev` and `build`. Do not edit directly `theme.json` as it will be over written on build. 
+
+Several of the Tailwind variables are pulled in and Tailwind should be used as the primary way to style elements. If you need to, you can pull in more Tailwind variable for custom styling in `theme.json`.
+
+## Custom Blocks
+Builds are build using ACF and core WordPress blocks. Styles for the blocks are in `src/styles/blocks`.
+
+* Accordion
+* Alert Banner
+* CTA
+* Image Caption
+* Logo Grid
+* Text Icon Cards
+* Text Image
+* Video Embed
+* *List other custom Blocks*


### PR DESCRIPTION
# Summary

Updating the readme files for users:

1. Developer working on the WP site starter files.
2. Developer starting up a new client project using the WP site starter files.
3. Developer setting up the client project on local dev.

The main `README` is for instance number 1. The `README.dist` is for instance number 2 and 3. 

## Issues

* #53

## Testing Instructions

1. Read through both readme and make sure what I added cover everything. 

## Screenshots

NA
