### PR TITLE
[#63] Logo Grid updating default justify content

### DIFF
--- a/wp-content/themes/wp-starter/blocks/logo-grid/block.json
+++ b/wp-content/themes/wp-starter/blocks/logo-grid/block.json
@@ -45,7 +45,7 @@
     "layout": {
       "default": {
         "type": "flex",
-        "justifyContent": "space-between",
+        "justifyContent": "left",
         "flexWrap": "wrap"
       },
       "allowOrientation": false,


### PR DESCRIPTION
# Summary

Justifying the content to be left by default. 

## Issues

* #63 

## Testing Instructions

1. Add the logo block to the page and make sure it defaults to be left justified.

## Screenshots

NA
