### PR TITLE
[#69] Styling the breadcrumbs

### DIFF
--- a/wp-content/themes/wp-starter/blocks/breadcrumbs/block.json
+++ b/wp-content/themes/wp-starter/blocks/breadcrumbs/block.json
@@ -21,12 +21,11 @@
     "layout": {
       "default": {
         "type": "constrained",
-        "justifyContent": "center"
+        "justifyContent": "left"
       },
       "allowCustomContentAndWideSize": false
     }
   },
-  "style": "file:./style.css",
   "acf": {
     "mode": "preview"
   }

--- a/wp-content/themes/wp-starter/blocks/breadcrumbs/patterns/breadcrumbs-inner-blocks.php
+++ b/wp-content/themes/wp-starter/blocks/breadcrumbs/patterns/breadcrumbs-inner-blocks.php
@@ -9,7 +9,8 @@
 
 ?>
 <!-- wp:buttons {"align":"wide","className":"is-style-breadcrumbs"} -->
-<div class="wp-block-buttons alignwide is-style-breadcrumbs"><!-- wp:button -->
+<div class="wp-block-buttons alignwide is-style-breadcrumbs">
+	<!-- wp:button -->
 	<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Breadcrumb</a></div>
 	<!-- /wp:button -->
 

--- a/wp-content/themes/wp-starter/blocks/page-header/patterns/page-header-inner-blocks.php
+++ b/wp-content/themes/wp-starter/blocks/page-header/patterns/page-header-inner-blocks.php
@@ -11,17 +11,22 @@
 <!-- wp:acf/breadcrumbs {"name":"acf/breadcrumbs","data":{},"mode":"preview"} /-->
 
 <!-- wp:columns {"verticalAlignment":"center","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
-<div class="wp-block-columns are-vertically-aligned-center" style="margin-top:0;margin-bottom:0"><!-- wp:column {"verticalAlignment":"center","width":"66.66%"} -->
-	<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:66.66%"><!-- wp:post-title {"level":1} /-->
+<div class="wp-block-columns are-vertically-aligned-center" style="margin-top:0;margin-bottom:0">
+<!-- wp:column {"verticalAlignment":"center","width":"66.66%"} -->
+	<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:66.66%">
+		<!-- wp:post-title {"level":1,"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} /-->
 
 		<!-- wp:paragraph -->
 		<p>Page description ponam in culpa idiota aliis pravitatis. Principium ponere culpam in se justum praeceptum. Neque improperes et aliis qui non perfecte ipse docuit.</p>
-		<!-- /wp:paragraph --></div>
+		<!-- /wp:paragraph -->
+	</div>
 	<!-- /wp:column -->
 
 	<!-- wp:column {"verticalAlignment":"center","width":"33.33%"} -->
 	<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:33.33%"><!-- wp:image -->
 		<figure class="wp-block-image"><img alt=""/></figure>
-		<!-- /wp:image --></div>
-	<!-- /wp:column --></div>
+		<!-- /wp:image -->
+	</div>
+	<!-- /wp:column -->
+</div>
 <!-- /wp:columns -->

--- a/wp-content/themes/wp-starter/src/styles/custom-blocks/breadcrumbs.css
+++ b/wp-content/themes/wp-starter/src/styles/custom-blocks/breadcrumbs.css
@@ -1,0 +1,29 @@
+@layer components {
+	/* Rank Math breadcrumb styles */
+	.rank-math-breadcrumb {
+		p {
+			@apply flex flex-wrap gap-8;
+		}
+
+		a {
+			@apply text-sky-700 underline hover:no-underline focus:no-underline;
+		}
+	}
+
+	/* WP breadcrumb styles */
+	.is-style-breadcrumbs {
+		@apply flex flex-wrap gap-8;
+
+		.wp-block-button {
+			@apply after:ml-10 after:content-['>'];
+
+			&:last-of-type {
+				@apply after:hidden;
+			}
+
+			.wp-block-button__link.wp-element-button {
+				@apply !m-0 bg-transparent !p-0 text-sky-700 underline hover:bg-transparent hover:no-underline focus:bg-transparent focus:no-underline;
+			}
+		}
+	}
+}

--- a/wp-content/themes/wp-starter/src/styles/main.css
+++ b/wp-content/themes/wp-starter/src/styles/main.css
@@ -14,6 +14,7 @@
 /*Import custom styles for custom blocks*/
 @import './custom-blocks/accordion.css';
 @import './custom-blocks/alert-banner.css';
+@import './custom-blocks/breadcrumbs.css';
 @import './custom-blocks/buttons.css';
 @import './custom-blocks/cta.css';
 @import './custom-blocks/logo-grid.css';


### PR DESCRIPTION
# Summary

Styles the breadcrumbs with TW

## Issues

* #69

## Testing Instructions

1. Make sure the breadcrumbs look like the screenshots. 

## Screenshots

### Rank Math
<img width="332" alt="Screenshot 2024-05-21 at 2 40 50 PM" src="https://github.com/vigetlabs/wordpress-site-starter/assets/91974372/c5712f04-b3a7-42ce-9d4b-2c41e21c88c5">


### Default WP
<img width="377" alt="Screenshot 2024-05-21 at 2 40 34 PM" src="https://github.com/vigetlabs/wordpress-site-starter/assets/91974372/640c2c77-ac79-4a58-bc2d-81bb0427f9d1">
