### PR TITLE
[#93] Moving the delating to after DB install

### DIFF
--- a/bin/composer-scripts/ProjectEvents/PostInstallScript.php
+++ b/bin/composer-scripts/ProjectEvents/PostInstallScript.php
@@ -194,6 +194,10 @@ class PostInstallScript extends ComposerScript {
 	 * @return void
 	 */
 	private static function deleteCorePlugins(): void {
+		if ( ! self::isWordPressInstalled() ) {
+			self::writeError( 'WordPress installation failed. Can not delete stock WordPress plugins.' );
+			return;
+		}
 		self::writeInfo( 'Deleting stock WordPress plugins...' );
 
 		foreach ( self::$deletePlugins as $plugin ) {
@@ -505,6 +509,10 @@ class PostInstallScript extends ComposerScript {
 	 * @return void
 	 */
 	private static function activatePlugins(): void {
+		if ( ! self::isWordPressInstalled() ) {
+			self::writeError( 'WordPress installation failed. Can not activate stock WordPress plugins.' );
+			return;
+		}
 		self::writeComment( 'Activating plugins...' );
 
 		foreach ( self::$activatePlugins as $slug => $plugin ) {

--- a/bin/composer-scripts/ProjectEvents/PostInstallScript.php
+++ b/bin/composer-scripts/ProjectEvents/PostInstallScript.php
@@ -87,14 +87,14 @@ class PostInstallScript extends ComposerScript {
 
 			self::wait( 2 );
 
+			// Populate the database.
+			self::populateDatabase();
+
 			// Remove the core Twenty-X themes.
 			self::deleteCoreThemes();
 
 			// Remove Hello Dolly.
 			self::deleteCorePlugins();
-
-			// Populate the database.
-			self::populateDatabase();
 		}
 
 		// Run the Viget WP Composer Install


### PR DESCRIPTION
# Summary
The composer install does not delete the themes or the plugins. These two may to happen after the DB. So trying to run both of these after the DB is set up. 

@bd-viget not sure about this fix, but it may be the problem. You may have a better idea on what is going on and why the files are not getting removed. 

## Issues

* #93

## Testing Instructions

1. Can not test till merged with `main` and we run the install. 

## Screenshots

<img width="435" alt="Screenshot 2024-05-29 at 3 15 53 PM" src="https://github.com/vigetlabs/wordpress-site-starter/assets/91974372/9ff206e4-cbff-4a46-8cab-7bac825a4ef0">
