### PR TITLE
[n/a] Updating delete theme/plugins to warning

### DIFF
--- a/bin/composer-scripts/ProjectEvents/PostInstallScript.php
+++ b/bin/composer-scripts/ProjectEvents/PostInstallScript.php
@@ -165,6 +165,10 @@ class PostInstallScript extends ComposerScript {
 	 * @return void
 	 */
 	private static function deleteCoreThemes(): void {
+		if ( ! self::isWordPressInstalled() ) {
+			self::writeWarning( 'Could not delete stock WordPress themes.' );
+			return;
+		}
 		self::writeInfo( 'Deleting stock WordPress themes...' );
 
 		$themes = [
@@ -195,7 +199,7 @@ class PostInstallScript extends ComposerScript {
 	 */
 	private static function deleteCorePlugins(): void {
 		if ( ! self::isWordPressInstalled() ) {
-			self::writeError( 'WordPress installation failed. Can not delete stock WordPress plugins.' );
+			self::writeWarning( 'Could not delete stock WordPress plugins.' );
 			return;
 		}
 		self::writeInfo( 'Deleting stock WordPress plugins...' );
@@ -509,10 +513,6 @@ class PostInstallScript extends ComposerScript {
 	 * @return void
 	 */
 	private static function activatePlugins(): void {
-		if ( ! self::isWordPressInstalled() ) {
-			self::writeError( 'WordPress installation failed. Can not activate stock WordPress plugins.' );
-			return;
-		}
 		self::writeComment( 'Activating plugins...' );
 
 		foreach ( self::$activatePlugins as $slug => $plugin ) {


### PR DESCRIPTION
# Summary

This updates the composer post install `deleteCoreThemes` and `deleteCorePlugins` to return a warning if WP is not installed. 
I also noticed that I mistakenly added `isWordPressInstalled` to  `activatePlugins`, which is now removed. 

## Issues

* NA

## Testing Instructions

1. NA
