### PR TITLE
[#102] Removing parent wp-block class from button css

### DIFF
--- a/wp-content/themes/wp-starter/plugins-tailwind/buttons.js
+++ b/wp-content/themes/wp-starter/plugins-tailwind/buttons.js
@@ -29,7 +29,7 @@ module.exports = plugin.withOptions(function (options = {}) {
 				...base,
 				[`@apply
 				bg-${accentColor}-700 text-white
-				hover:bg-${accentColor}-700
+				hover:bg-${accentColor}-800
 				active:bg-${accentColor}-800
 				focus-visible:bg-${accentColor}-700 focus-visible:ring-${accentColor}-600/50`]: {},
 			},

--- a/wp-content/themes/wp-starter/src/styles/core-blocks/buttons.css
+++ b/wp-content/themes/wp-starter/src/styles/core-blocks/buttons.css
@@ -1,29 +1,26 @@
 @layer components {
-	.wp-block,
-	.acf-block {
+	.wp-block-button {
+		.wp-block-button__link {
+			@apply btn-contained;
+		}
+
+		&.is-style-outline {
+			.wp-block-button__link {
+				@apply btn-outlined;
+			}
+		}
+	}
+
+	/* Light versions for dark mode*/
+	[class*='has-dark'] {
 		.wp-block-button {
 			.wp-block-button__link {
-				@apply btn-contained;
+				@apply btn-contained-light;
 			}
 
 			&.is-style-outline {
 				.wp-block-button__link {
-					@apply btn-outlined;
-				}
-			}
-		}
-
-		/* Light versions for dark mode*/
-		&[class*='has-dark'] {
-			.wp-block-button {
-				.wp-block-button__link {
-					@apply btn-contained-light;
-				}
-
-				&.is-style-outline {
-					.wp-block-button__link {
-						@apply btn-outlined-light;
-					}
+					@apply btn-outlined-light;
 				}
 			}
 		}


### PR DESCRIPTION
# Summary
Bug I found when styling the buttons on a client project. The buttons styles correctly if they are in a pattern/component but not if they are just a button in the WP core Button group. Removing the parent classes fixes the problem. 

## Issues

* #102

## Testing Instructions

1. Add the button group to a page and make sure they are styled in the WP editor and the frontend.
2. Make sure the buttons are styled in our blocks. 

## Screenshots

### With parents classes on buttons css
<img width="255" alt="Screenshot 2024-06-14 at 2 40 40 PM" src="https://github.com/vigetlabs/wordpress-site-starter/assets/91974372/dcdf56da-5be4-40f5-9222-5fbf9158de3c">


### With OUT parents classes on buttons css
<img width="222" alt="Screenshot 2024-06-14 at 2 40 12 PM" src="https://github.com/vigetlabs/wordpress-site-starter/assets/91974372/c3692d76-71f8-4663-b0b1-02877d25c2db">