### PR TITLE
[#104] Check if we are in dev mode on post install script

### DIFF
--- a/bin/composer-scripts/ProjectEvents/PostInstallScript.php
+++ b/bin/composer-scripts/ProjectEvents/PostInstallScript.php
@@ -76,6 +76,11 @@ class PostInstallScript extends ComposerScript {
 	public static function execute( Event $event ): void {
 		self::setEvent( $event );
 
+		// Only run the rest of the script if we are in development mode.
+		if ( !$event->isDevMode() ) {
+			return;
+		}
+
 		// Load DDEV Environment variables.
 		self::loadDDEVEnvironmentVars();
 


### PR DESCRIPTION
# Summary
Ran into this when Nevin was setting up the deploy script. When Github trys to deploy to a server like WP Engine it tries to set up DDEV for local development of which it fails and then the whole deploy script fails. 
Nevin created a fix for this on a client project. So bringing that fix over to the starter so we don't run into it again. 

## Issues

* #104 

## Testing Instructions

1. Not really a way to test this, but the deployment now works on that project.