### PR TITLE
[#114] Allow Skip Cropping

### DIFF
--- a/wp-content/mu-plugins/viget-wp/src/assets/js/skip-cropping.js
+++ b/wp-content/mu-plugins/viget-wp/src/assets/js/skip-cropping.js
@@ -1,0 +1,40 @@
+/**
+ * This allows the user to skip the cropping step when uploading a site icon.
+ *
+ * @package VigetWP
+ */
+
+(function($, wp) {
+    $(document).ready(function() {
+        if (!wp.media) {
+            return;
+        }
+
+        const originalController = wp.media.controller.SiteIconCropper;
+
+        wp.media.controller.SiteIconCropper = originalController.extend({
+            activate: function() {
+                originalController.prototype.activate.apply(this, arguments);
+                this.set('canSkipCrop', true);
+            }
+        });
+
+        const originalButton = wp.media.view.Button;
+
+        wp.media.view.Button = originalButton.extend({
+            click: function( e ) {
+                if (!this.options.classes.includes('media-button-skip')) {
+                    originalButton.prototype.click.apply(this, arguments);
+                    return;
+                }
+
+                e.preventDefault();
+
+                const controller = this.controller;
+                const attachment = controller.state().get('selection').first().toJSON();
+                controller.trigger('cropped', attachment);
+                controller.close();
+            }
+        });
+    });
+})(jQuery, wp);

--- a/wp-content/mu-plugins/viget-wp/src/classes/Admin/Assets.php
+++ b/wp-content/mu-plugins/viget-wp/src/classes/Admin/Assets.php
@@ -28,11 +28,33 @@ class Assets {
 		add_action(
 			'admin_enqueue_scripts',
 			function () {
+				$version = vigetwp()->get_version();
+
+				if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+					$js_path = VIGETWP_PLUGIN_PATH . 'src/assets/js/skip-cropping.js';
+					$version = filemtime( $js_path );
+				}
+
+				wp_enqueue_script(
+					'vigetwp-admin-skip-cropping',
+					VIGETWP_PLUGIN_URL . 'src/assets/js/skip-cropping.js',
+					[ 'jquery', 'media-views' ],
+					$version,
+					[
+						'in_footer' => true,
+					]
+				);
+
+				if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+					$css_path = VIGETWP_PLUGIN_PATH . 'src/assets/css/admin.css';
+					$version  = filemtime( $css_path );
+				}
+
 				wp_enqueue_style(
 					'vigetwp-admin-styles',
 					VIGETWP_PLUGIN_URL . 'src/assets/css/admin.css',
 					[], // dependencies.
-					vigetwp()->get_version()
+					$version
 				);
 			}
 		);


### PR DESCRIPTION
# Summary

Allows the user to skip the cropping step when uploading a site icon in the case of the icon being an SVG.

## Issues

* #114 

## Testing Instructions

1. Upload SVG to Site Icon under Settings > General
2. Click Skip Cropping
3. Save Changes
