### PR TITLE
[N/A] Fix editor bug w/inline-block

### DIFF
--- a/wp-content/themes/wp-starter/src/styles/core-blocks/list.css
+++ b/wp-content/themes/wp-starter/src/styles/core-blocks/list.css
@@ -1,7 +1,5 @@
 @layer components {
-	.block-editor-block-list__block {
-		.block-editor-rich-text__editable.rich-text {
-			@apply inline-block;
-		}
+	[data-type="core/list-item"] .block-editor-rich-text__editable.rich-text {
+		@apply inline-block;
 	}
 }


### PR DESCRIPTION
# Summary

This PR fixes an issue where elements were displayed `inline-block` in the editor.

## Issues

* #108 

## Testing Instructions

1. Create a CTA block.
2. View on a wide screen inside the editor
3. Make sure the heading and paragraph elements are not inline with each other.

## Screenshots

**Fixes this issue**
<img width="1227" alt="Screenshot 2024-06-14 at 2 01 56 PM" src="https://github.com/vigetlabs/wordpress-site-starter/assets/122309362/c26d3857-acc1-4037-be74-a6b97a3f1fe3">
