### PR TITLE
[#129] Auto Create Blocks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"twiggy.framework": "ignore"
+}

--- a/wp-content/themes/wp-starter/README.md
+++ b/wp-content/themes/wp-starter/README.md
@@ -24,6 +24,21 @@ Blocks are build using ACF and core WordPress blocks. Styles for the blocks are 
 * Text Image
 * Video Embed
 
+### Creating New Blocks
+The theme is set up with [plop](https://plopjs.com/) which will auto generate a new block based on the options you input. 
+In order build a new block run:
+
+```
+ddev npm run plop block
+```
+
+It will ask you a few question:
+* __What is the block name?__ - *This can be whatever you want.*
+* __What is the slug for your theme?__ - *This would your theme slug. If you are unsure of what that is, you can look at `textdomain:` in side of any `block.json` files.*
+* __Pick a WordPress icon for the block__ - *Icons are from [WordPress Icons](https://developer.wordpress.org/resource/dashicons/) and you can change the icon if you don't see one you want.*
+* __Do you need block styles?__ - *Adds the option for adding a class to the block’s wrapper - [Block Styles](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/)*
+* __Do you need block variations?__ - *Adds the option for a block variant - [Block Variations](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-variations/)*
+
 ## Customizing Theme 🎨
 ### Fonts
 Fonts are pulled in by [typography.js](/src/theme-json/settings/typography.js). Update the `src` to pull in the font files in `/src/fonts`. For more info on setting up WordPress fonts check out [fullsiteediting](https://fullsiteediting.com/lessons/creating-theme-json/#h-typography).

--- a/wp-content/themes/wp-starter/package-lock.json
+++ b/wp-content/themes/wp-starter/package-lock.json
@@ -23,6 +23,7 @@
 				"install": "^0.13.0",
 				"npm": "^10.5.2",
 				"path": "^0.12.7",
+				"plop": "^4.0.1",
 				"postcss": "^8.4.38",
 				"postcss-import": "^16.1.0",
 				"postcss-nested-import": "^0.2.0",
@@ -523,6 +524,15 @@
 			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
 			"dev": true
 		},
+		"node_modules/@inquirer/figures": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.5.tgz",
+			"integrity": "sha512-79hP/VWdZ2UVc9bFGJnoQ/lQMpL74mGgzSYX1xUqCVk7/v73vJCMw1VuyWN1jGkZ9B3z7THAbySqGbCNefcjfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -866,11 +876,55 @@
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
 			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
 		},
+		"node_modules/@types/fined": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@types/fined/-/fined-1.1.5.tgz",
+			"integrity": "sha512-2N93vadEGDFhASTIRbizbl4bNqpMOId5zZfj6hHqYZfEzEfO9onnU4Im8xvzo8uudySDveDHBOOSlTWf38ErfQ==",
+			"dev": true
+		},
+		"node_modules/@types/inquirer": {
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-9.0.7.tgz",
+			"integrity": "sha512-Q0zyBupO6NxGRZut/JdmqYKOnN95Eg5V8Csg3PGKkP+FnvsUZx1jAyK7fztIszxxMuoBA6E3KXWvdZVXIpx60g==",
+			"dev": true,
+			"dependencies": {
+				"@types/through": "*",
+				"rxjs": "^7.2.0"
+			}
+		},
 		"node_modules/@types/json5": {
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
+		},
+		"node_modules/@types/liftoff": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/liftoff/-/liftoff-4.0.3.tgz",
+			"integrity": "sha512-UgbL2kR5pLrWICvr8+fuSg0u43LY250q7ZMkC+XKC3E+rs/YBDEnQIzsnhU5dYsLlwMi3R75UvCL87pObP1sxw==",
+			"dev": true,
+			"dependencies": {
+				"@types/fined": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "20.14.12",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
+			"integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
+			"devOptional": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/@types/through": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
+			"integrity": "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@ungap/structured-clone": {
 			"version": "1.2.0",
@@ -917,6 +971,22 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/aggregate-error": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+			"integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
+			"dev": true,
+			"dependencies": {
+				"clean-stack": "^4.0.0",
+				"indent-string": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -939,6 +1009,33 @@
 			"integrity": "sha512-86RB307VWICex0vG15Eq0x058cNNsvS57ohrjN6n/TJAVSFV+zXOK/E34nNHDHc6Poq+yTNCLqEzPqEkRBTMRQ==",
 			"dependencies": {
 				"@vue/reactivity": "~3.1.1"
+			}
+		},
+		"node_modules/ansi-escapes": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^0.21.3"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ansi-escapes/node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -1011,6 +1108,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/array-each": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+			"integrity": "sha512-zHjL5SZa68hkKHBFBK6DJCTtr9sfTCPCaph/L7tMSLcTFgy+zX7E+6q5UArbtOtMBCtxdICpfTCspRse+ywyXA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/array-includes": {
 			"version": "3.1.8",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
@@ -1029,6 +1135,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array-slice": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+			"integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/array.prototype.findlastindex": {
@@ -1167,6 +1282,26 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1176,6 +1311,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"dev": true,
+			"dependencies": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
 			}
 		},
 		"node_modules/boolbase": {
@@ -1237,6 +1383,30 @@
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
 		},
+		"node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
 		"node_modules/call-bind": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -1263,6 +1433,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/camel-case": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+			"dev": true,
+			"dependencies": {
+				"pascal-case": "^3.1.2",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/camelcase-css": {
@@ -1306,6 +1486,17 @@
 				}
 			]
 		},
+		"node_modules/capital-case": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+			"dev": true,
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case-first": "^2.0.2"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1321,6 +1512,32 @@
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
+		},
+		"node_modules/change-case": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+			"dev": true,
+			"dependencies": {
+				"camel-case": "^4.1.2",
+				"capital-case": "^1.0.4",
+				"constant-case": "^3.0.4",
+				"dot-case": "^3.0.4",
+				"header-case": "^2.0.4",
+				"no-case": "^3.0.4",
+				"param-case": "^3.0.4",
+				"pascal-case": "^3.1.2",
+				"path-case": "^3.0.4",
+				"sentence-case": "^3.0.4",
+				"snake-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/chardet": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"dev": true
 		},
 		"node_modules/chokidar": {
 			"version": "3.6.0",
@@ -1354,6 +1571,78 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/clean-stack": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+			"integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "5.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/clean-stack/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-cursor": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+			"integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+			"dev": true,
+			"dependencies": {
+				"restore-cursor": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-spinners": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+			"integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-width": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8"
 			}
 		},
 		"node_modules/color-convert": {
@@ -1394,6 +1683,17 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
+		},
+		"node_modules/constant-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+			"dev": true,
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case": "^2.0.2"
+			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -1669,6 +1969,18 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
+		"node_modules/defaults": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+			"integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+			"dev": true,
+			"dependencies": {
+				"clone": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/define-data-property": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -1703,11 +2015,66 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/del": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-7.1.0.tgz",
+			"integrity": "sha512-v2KyNk7efxhlyHpjEvfyxaAihKKK0nWCuf6ZtqZcFFpQRG0bJ12Qsr0RpvsICMjAAZ8DOVCxrlqpxISlMHC4Kg==",
+			"dev": true,
+			"dependencies": {
+				"globby": "^13.1.2",
+				"graceful-fs": "^4.2.10",
+				"is-glob": "^4.0.3",
+				"is-path-cwd": "^3.0.0",
+				"is-path-inside": "^4.0.0",
+				"p-map": "^5.5.0",
+				"rimraf": "^3.0.2",
+				"slash": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/del/node_modules/is-path-inside": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+			"integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/detect-file": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+			"integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/didyoumean": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
 			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
 			"dev": true
+		},
+		"node_modules/dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
+			"dependencies": {
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/dlv": {
 			"version": "1.1.3",
@@ -1780,6 +2147,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/dot-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+			"dev": true,
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/eastasianwidth": {
@@ -2255,6 +2632,38 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/expand-tilde": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+			"integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+			"dev": true,
+			"dependencies": {
+				"homedir-polyfill": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
+		},
+		"node_modules/external-editor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+			"dev": true,
+			"dependencies": {
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
+				"tmp": "^0.0.33"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2349,6 +2758,46 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/findup-sync": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
+			"integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
+			"dev": true,
+			"dependencies": {
+				"detect-file": "^1.0.0",
+				"is-glob": "^4.0.3",
+				"micromatch": "^4.0.4",
+				"resolve-dir": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/fined": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fined/-/fined-2.0.0.tgz",
+			"integrity": "sha512-OFRzsL6ZMHz5s0JrsEr+TpdGNCtrVtnuG3x1yzGNiQHT0yaDnXAj8V/lWcpJVrnoDpcwXcASxAZYbuXda2Y82A==",
+			"dev": true,
+			"dependencies": {
+				"expand-tilde": "^2.0.2",
+				"is-plain-object": "^5.0.0",
+				"object.defaults": "^1.1.0",
+				"object.pick": "^1.3.0",
+				"parse-filepath": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/flagged-respawn": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-2.0.0.tgz",
+			"integrity": "sha512-Gq/a6YCi8zexmGHMuJwahTGzXlAZAOsbCVKduWXC6TlLCjjFRlExMJc4GC2NYPYZ0r/brw9P7CpRgQmlPVeOoA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
 		"node_modules/flat-cache": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -2384,6 +2833,27 @@
 			"dev": true,
 			"dependencies": {
 				"is-callable": "^1.1.3"
+			}
+		},
+		"node_modules/for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/for-own": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+			"integrity": "sha512-0OABksIGrxKK8K4kynWkQ7y1zounQxP+CWnyclVwj81KW3vlLlGUx57DKGcP/LH216GzqnstnPocF16Nxs0Ycg==",
+			"dev": true,
+			"dependencies": {
+				"for-in": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/foreground-child": {
@@ -2470,6 +2940,18 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+			"integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/get-intrinsic": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -2538,6 +3020,48 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/global-modules": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+			"dev": true,
+			"dependencies": {
+				"global-prefix": "^1.0.1",
+				"is-windows": "^1.0.1",
+				"resolve-dir": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/global-prefix": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+			"integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
+			"dev": true,
+			"dependencies": {
+				"expand-tilde": "^2.0.2",
+				"homedir-polyfill": "^1.0.1",
+				"ini": "^1.3.4",
+				"is-windows": "^1.0.1",
+				"which": "^1.2.14"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/global-prefix/node_modules/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
 		"node_modules/globals": {
 			"version": "13.24.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -2568,6 +3092,25 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/globby": {
+			"version": "13.2.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+			"integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+			"dev": true,
+			"dependencies": {
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.3.0",
+				"ignore": "^5.2.4",
+				"merge2": "^1.4.1",
+				"slash": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/gopd": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -2580,11 +3123,38 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true
+		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
+		},
+		"node_modules/handlebars": {
+			"version": "4.7.8",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.2",
+				"source-map": "^0.6.1",
+				"wordwrap": "^1.0.0"
+			},
+			"bin": {
+				"handlebars": "bin/handlebars"
+			},
+			"engines": {
+				"node": ">=0.4.7"
+			},
+			"optionalDependencies": {
+				"uglify-js": "^3.1.4"
+			}
 		},
 		"node_modules/has-bigints": {
 			"version": "1.0.2",
@@ -2667,6 +3237,60 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/header-case": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+			"dev": true,
+			"dependencies": {
+				"capital-case": "^1.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/homedir-polyfill": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+			"dev": true,
+			"dependencies": {
+				"parse-passwd": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/ignore": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -2701,6 +3325,18 @@
 				"node": ">=0.8.19"
 			}
 		},
+		"node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2716,6 +3352,160 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
+		},
+		"node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true
+		},
+		"node_modules/inquirer": {
+			"version": "9.3.6",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.3.6.tgz",
+			"integrity": "sha512-riK/iQB2ctwkpWYgjjWIRv3MBLt2gzb2Sj0JNQNbyTXgyXsLWcDPJ5WS5ZDTCx7BRFnJsARtYh+58fjP5M2Y0Q==",
+			"dev": true,
+			"dependencies": {
+				"@inquirer/figures": "^1.0.3",
+				"ansi-escapes": "^4.3.2",
+				"cli-width": "^4.1.0",
+				"external-editor": "^3.1.0",
+				"mute-stream": "1.0.0",
+				"ora": "^5.4.1",
+				"run-async": "^3.0.0",
+				"rxjs": "^7.8.1",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^6.2.0",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/inquirer/node_modules/cli-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+			"dev": true,
+			"dependencies": {
+				"restore-cursor": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/inquirer/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/inquirer/node_modules/is-interactive": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/inquirer/node_modules/is-unicode-supported": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/inquirer/node_modules/log-symbols": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.0",
+				"is-unicode-supported": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/inquirer/node_modules/ora": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+			"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+			"dev": true,
+			"dependencies": {
+				"bl": "^4.1.0",
+				"chalk": "^4.1.0",
+				"cli-cursor": "^3.1.0",
+				"cli-spinners": "^2.5.0",
+				"is-interactive": "^1.0.0",
+				"is-unicode-supported": "^0.1.0",
+				"log-symbols": "^4.1.0",
+				"strip-ansi": "^6.0.0",
+				"wcwidth": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/inquirer/node_modules/restore-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+			"dev": true,
+			"dependencies": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/inquirer/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
+		},
+		"node_modules/inquirer/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/inquirer/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/install": {
 			"version": "0.13.0",
@@ -2738,6 +3528,28 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/interpret": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+			"integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/is-absolute": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+			"integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+			"dev": true,
+			"dependencies": {
+				"is-relative": "^1.0.0",
+				"is-windows": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -2877,6 +3689,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-interactive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+			"integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -2912,6 +3736,18 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-path-cwd": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-3.0.0.tgz",
+			"integrity": "sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-path-inside": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -2919,6 +3755,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-regex": {
@@ -2935,6 +3780,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-relative": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+			"integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+			"dev": true,
+			"dependencies": {
+				"is-unc-path": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-shared-array-buffer": {
@@ -2997,6 +3854,30 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-unc-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+			"integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+			"dev": true,
+			"dependencies": {
+				"unc-path-regex": "^0.1.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-unicode-supported": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
+			"integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-weakref": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -3009,17 +3890,47 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/isarray": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
 			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
 			"dev": true
 		},
+		"node_modules/isbinaryfile": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.2.tgz",
+			"integrity": "sha512-GvcjojwonMjWbTkfMpnVHVqXW/wKMYDfEpY94/8zy8HFMOqb/VL6oeONq9v87q4ttVlaTLnGXnJD4B5B1OTGIg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/gjtorikian/"
+			}
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
+		},
+		"node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/jackspeak": {
 			"version": "2.3.6",
@@ -3099,6 +4010,15 @@
 				"json-buffer": "3.0.1"
 			}
 		},
+		"node_modules/kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3110,6 +4030,25 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/liftoff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/liftoff/-/liftoff-4.0.0.tgz",
+			"integrity": "sha512-rMGwYF8q7g2XhG2ulBmmJgWv25qBsqRbDn5gH0+wnuyeFt7QBJlHJmtg5qEdn4pN6WVAUMgXnIxytMFRX9c1aA==",
+			"dev": true,
+			"dependencies": {
+				"extend": "^3.0.2",
+				"findup-sync": "^5.0.0",
+				"fined": "^2.0.0",
+				"flagged-respawn": "^2.0.0",
+				"is-plain-object": "^5.0.0",
+				"object.map": "^1.0.1",
+				"rechoir": "^0.8.0",
+				"resolve": "^1.20.0"
+			},
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/lilconfig": {
@@ -3142,6 +4081,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+			"dev": true
+		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -3159,6 +4104,76 @@
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
 			"dev": true
+		},
+		"node_modules/log-symbols": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+			"integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^5.3.0",
+				"is-unicode-supported": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-symbols/node_modules/chalk": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+			"dev": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/log-symbols/node_modules/is-unicode-supported": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+			"integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/lower-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/make-iterator": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+			"integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+			"dev": true,
+			"dependencies": {
+				"kind-of": "^6.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/mdn-data": {
 			"version": "2.0.30",
@@ -3186,6 +4201,15 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/minimatch": {
@@ -3218,11 +4242,35 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
+		"node_modules/mkdirp": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+			"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+			"dev": true,
+			"bin": {
+				"mkdirp": "dist/cjs/src/bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
+		},
+		"node_modules/mute-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+			"integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+			"dev": true,
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
 		},
 		"node_modules/mz": {
 			"version": "2.7.0",
@@ -3257,6 +4305,46 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node_modules/neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"dev": true
+		},
+		"node_modules/no-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+			"dev": true,
+			"dependencies": {
+				"lower-case": "^2.0.2",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/node-plop": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/node-plop/-/node-plop-0.32.0.tgz",
+			"integrity": "sha512-lKFSRSRuDHhwDKMUobdsvaWCbbDRbV3jMUSMiajQSQux1aNUevAZVxUHc2JERI//W8ABPRbi3ebYuSuIzkNIpQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/inquirer": "^9.0.3",
+				"change-case": "^4.1.2",
+				"del": "^7.1.0",
+				"globby": "^13.2.2",
+				"handlebars": "^4.7.8",
+				"inquirer": "^9.2.10",
+				"isbinaryfile": "^5.0.0",
+				"lodash.get": "^4.4.2",
+				"lower-case": "^2.0.2",
+				"mkdirp": "^3.0.1",
+				"resolve": "^1.22.4",
+				"title-case": "^3.0.3",
+				"upper-case": "^2.0.2"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.14",
@@ -6148,6 +7236,21 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/object.defaults": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+			"integrity": "sha512-c/K0mw/F11k4dEUBMW8naXUuBuhxRCfG7W+yFy8EcijU/rSmazOUd1XAEEe6bC0OuXY4HUKjTJv7xbxIMqdxrA==",
+			"dev": true,
+			"dependencies": {
+				"array-each": "^1.0.1",
+				"array-slice": "^1.0.0",
+				"for-own": "^1.0.0",
+				"isobject": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/object.fromentries": {
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
@@ -6180,6 +7283,31 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/object.map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+			"integrity": "sha512-3+mAJu2PLfnSVGHwIWubpOFLscJANBKuB/6A4CxBstc4aqwQY0FWcsppuy4jU5GSB95yES5JHSI+33AWuS4k6w==",
+			"dev": true,
+			"dependencies": {
+				"for-own": "^1.0.0",
+				"make-iterator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
+			"dev": true,
+			"dependencies": {
+				"isobject": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/object.values": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
@@ -6206,6 +7334,21 @@
 				"wrappy": "1"
 			}
 		},
+		"node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/optionator": {
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -6221,6 +7364,100 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/ora": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-8.0.1.tgz",
+			"integrity": "sha512-ANIvzobt1rls2BDny5fWZ3ZVKyD6nscLvfFRpQgfWsythlcsVUC9kL0zq6j2Z5z9wwp1kd7wpsD/T9qNPVLCaQ==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^5.3.0",
+				"cli-cursor": "^4.0.0",
+				"cli-spinners": "^2.9.2",
+				"is-interactive": "^2.0.0",
+				"is-unicode-supported": "^2.0.0",
+				"log-symbols": "^6.0.0",
+				"stdin-discarder": "^0.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ora/node_modules/chalk": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+			"dev": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/ora/node_modules/emoji-regex": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+			"integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+			"dev": true
+		},
+		"node_modules/ora/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/p-limit": {
@@ -6253,6 +7490,31 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/p-map": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
+			"integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
+			"dev": true,
+			"dependencies": {
+				"aggregate-error": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/param-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+			"dev": true,
+			"dependencies": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6265,6 +7527,39 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/parse-filepath": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+			"integrity": "sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q==",
+			"dev": true,
+			"dependencies": {
+				"is-absolute": "^1.0.0",
+				"map-cache": "^0.2.0",
+				"path-root": "^0.1.1"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/parse-passwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/pascal-case": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+			"dev": true,
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/path": {
 			"version": "0.12.7",
 			"resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
@@ -6273,6 +7568,16 @@
 			"dependencies": {
 				"process": "^0.11.1",
 				"util": "^0.10.3"
+			}
+		},
+		"node_modules/path-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+			"dev": true,
+			"dependencies": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/path-exists": {
@@ -6308,6 +7613,27 @@
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
+		"node_modules/path-root": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+			"integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
+			"dev": true,
+			"dependencies": {
+				"path-root-regex": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/path-root-regex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+			"integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/path-scurry": {
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
@@ -6331,6 +7657,15 @@
 			"dev": true,
 			"engines": {
 				"node": "14 || >=16.14"
+			}
+		},
+		"node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/picocolors": {
@@ -6365,6 +7700,40 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/plop": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/plop/-/plop-4.0.1.tgz",
+			"integrity": "sha512-5n8QU93kvL/ObOzBcPAB1siVFtAH1TZM6TntJ3JK5kXT0jIgnQV+j+uaOWWFJlg1cNkzLYm8klgASF65K36q9w==",
+			"dev": true,
+			"dependencies": {
+				"@types/liftoff": "^4.0.3",
+				"chalk": "^5.3.0",
+				"interpret": "^3.1.1",
+				"liftoff": "^4.0.0",
+				"minimist": "^1.2.8",
+				"node-plop": "^0.32.0",
+				"ora": "^8.0.0",
+				"v8flags": "^4.0.1"
+			},
+			"bin": {
+				"plop": "bin/plop.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/plop/node_modules/chalk": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+			"dev": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/possible-typed-array-names": {
@@ -7046,6 +8415,20 @@
 				"pify": "^2.3.0"
 			}
 		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7055,6 +8438,18 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/rechoir": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+			"integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+			"dev": true,
+			"dependencies": {
+				"resolve": "^1.20.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
 			}
 		},
 		"node_modules/regexp.prototype.flags": {
@@ -7092,6 +8487,19 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/resolve-dir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+			"integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
+			"dev": true,
+			"dependencies": {
+				"expand-tilde": "^2.0.0",
+				"global-modules": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -7100,6 +8508,28 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/restore-cursor": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+			"integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+			"dev": true,
+			"dependencies": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/restore-cursor/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
 		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
@@ -7160,6 +8590,15 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/run-async": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+			"integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7183,6 +8622,15 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/rxjs": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
 		"node_modules/safe-array-concat": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
@@ -7201,6 +8649,26 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/safe-regex-test": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
@@ -7218,6 +8686,12 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
 		"node_modules/semver": {
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -7225,6 +8699,17 @@
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/sentence-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+			"dev": true,
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case-first": "^2.0.2"
 			}
 		},
 		"node_modules/set-function-length": {
@@ -7310,12 +8795,64 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/slash": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/snake-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+			"dev": true,
+			"dependencies": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
 			"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stdin-discarder": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+			"integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/string-width": {
@@ -7706,6 +9243,27 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/title-case": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+			"integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
+			"dependencies": {
+				"os-tmpdir": "~1.0.2"
+			},
+			"engines": {
+				"node": ">=0.6.0"
+			}
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7734,6 +9292,12 @@
 				"minimist": "^1.2.6",
 				"strip-bom": "^3.0.0"
 			}
+		},
+		"node_modules/tslib": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"dev": true
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -7845,6 +9409,19 @@
 				"node": ">=4.2.0"
 			}
 		},
+		"node_modules/uglify-js": {
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.0.tgz",
+			"integrity": "sha512-wNKHUY2hYYkf6oSFfhwwiHo4WCHzHmzcXsqXYTN9ja3iApYIFbb2U6ics9hBcYLHcYGQoAlwnZlTrf3oF+BL/Q==",
+			"dev": true,
+			"optional": true,
+			"bin": {
+				"uglifyjs": "bin/uglifyjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -7859,6 +9436,21 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/unc-path-regex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+			"integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"devOptional": true
 		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.0.13",
@@ -7890,6 +9482,24 @@
 				"browserslist": ">= 4.21.0"
 			}
 		},
+		"node_modules/upper-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/upper-case-first": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -7919,6 +9529,15 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
 			"dev": true
+		},
+		"node_modules/v8flags": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-4.0.1.tgz",
+			"integrity": "sha512-fcRLaS4H/hrZk9hYwbdRM35D0U8IYMfEClhXxCivOojl+yTRAZH3Zy2sSy6qVCiGbV9YAtPssP6jaChqC9vPCg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10.13.0"
+			}
 		},
 		"node_modules/vite": {
 			"version": "5.2.11",
@@ -7986,6 +9605,15 @@
 				"vite": "^4.0.0 || ^5.0.0"
 			}
 		},
+		"node_modules/wcwidth": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+			"dev": true,
+			"dependencies": {
+				"defaults": "^1.0.3"
+			}
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8035,6 +9663,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+			"dev": true
 		},
 		"node_modules/wrap-ansi": {
 			"version": "8.1.0",
@@ -8155,6 +9789,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yoctocolors-cjs": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+			"integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/wp-content/themes/wp-starter/package.json
+++ b/wp-content/themes/wp-starter/package.json
@@ -11,7 +11,7 @@
 		"build": "vite build",
 		"format": "prettier \"./src/**/*.{css,ts,tsx,js}\" --check",
 		"format:fix": "prettier \"./src/**/*.{css,ts,tsx,js}\" --write",
-    "plop": "plop"
+    "new:block": "plop"
 	},
 	"devDependencies": {
 		"autoprefixer": "^10.4.19",

--- a/wp-content/themes/wp-starter/package.json
+++ b/wp-content/themes/wp-starter/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "wp-starter",
 	"version": "0.1.0",
+  "type": "commonjs",
 	"engines": {
 		"node": ">=20.0.0",
 		"npm": ">=10.0.0"
@@ -9,7 +10,8 @@
 		"dev": "APP_ENV=dev vite --host",
 		"build": "vite build",
 		"format": "prettier \"./src/**/*.{css,ts,tsx,js}\" --check",
-		"format:fix": "prettier \"./src/**/*.{css,ts,tsx,js}\" --write"
+		"format:fix": "prettier \"./src/**/*.{css,ts,tsx,js}\" --write",
+    "plop": "plop"
 	},
 	"devDependencies": {
 		"autoprefixer": "^10.4.19",
@@ -20,6 +22,7 @@
 		"install": "^0.13.0",
 		"npm": "^10.5.2",
 		"path": "^0.12.7",
+		"plop": "^4.0.1",
 		"postcss": "^8.4.38",
 		"postcss-import": "^16.1.0",
 		"postcss-nested-import": "^0.2.0",

--- a/wp-content/themes/wp-starter/package.json
+++ b/wp-content/themes/wp-starter/package.json
@@ -11,7 +11,7 @@
 		"build": "vite build",
 		"format": "prettier \"./src/**/*.{css,ts,tsx,js}\" --check",
 		"format:fix": "prettier \"./src/**/*.{css,ts,tsx,js}\" --write",
-    "new:block": "plop"
+		"plop": "plop"
 	},
 	"devDependencies": {
 		"autoprefixer": "^10.4.19",

--- a/wp-content/themes/wp-starter/plop-templates/block.json.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/block.json.hbs
@@ -4,7 +4,7 @@
   "description": "Displays the {{titleCase name}}",
   "icon": "{{icon}}",
   "category": "components",
-  "textdomain": "wp-starter",
+  "textdomain": "{{dashCase themeslug}}",
   "keywords": ["{{dashCase name}}"],
   "attributes": {
     "align": {

--- a/wp-content/themes/wp-starter/plop-templates/block.json.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/block.json.hbs
@@ -2,7 +2,7 @@
   "name": "{{dashCase name}}",
   "title": "{{titleCase name}}",
   "description": "Displays the {{titleCase name}}",
-  "icon": "{{icon}}",
+  "icon": "block-default",
   "category": "components",
   "textdomain": "{{dashCase themeslug}}",
   "keywords": ["{{dashCase name}}"],

--- a/wp-content/themes/wp-starter/plop-templates/block.json.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/block.json.hbs
@@ -2,7 +2,7 @@
   "name": "{{dashCase name}}",
   "title": "{{titleCase name}}",
   "description": "Displays the {{titleCase name}}",
-  "icon": "schedule",
+  "icon": "{{icon}}",
   "category": "components",
   "textdomain": "wp-starter",
   "keywords": ["{{dashCase name}}"],

--- a/wp-content/themes/wp-starter/plop-templates/block.json.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/block.json.hbs
@@ -33,8 +33,8 @@
       "background": true
     }
   },
-  -- PREPEND STYLES HERE --
-  -- PREPEND VARIATIONS HERE --
+  -- STYLES HERE --
+  -- VARIATIONS HERE --
   "acf": {
     "mode": "preview"
   }

--- a/wp-content/themes/wp-starter/plop-templates/block.json.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/block.json.hbs
@@ -1,0 +1,17 @@
+{
+  "name": "{{dashCase name}}",
+  "title": "{{titleCase name}}",
+  "description": "Displays the {{titleCase name}}",
+  "icon": "schedule",
+  "category": "components",
+  "textdomain": "wp-starter",
+  "keywords": ["{{dashCase name}}"],
+  "supports": {
+    "jsx": true,
+    "mode": false,
+    "alignWide": true
+  },
+  "acf": {
+    "mode": "preview"
+  }
+}

--- a/wp-content/themes/wp-starter/plop-templates/block.json.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/block.json.hbs
@@ -6,11 +6,35 @@
   "category": "components",
   "textdomain": "wp-starter",
   "keywords": ["{{dashCase name}}"],
+  "attributes": {
+    "align": {
+      "type": "string",
+      "default": "full"
+    },
+    "style": {
+      "type": "object",
+      "default": {
+        "spacing": {
+          "padding": {
+            "top": "var:preset|spacing|20",
+            "bottom": "var:preset|spacing|20",
+            "left": "var:preset|spacing|20",
+            "right": "var:preset|spacing|20"
+         }
+        }
+      }
+    }
+  },
   "supports": {
     "jsx": true,
     "mode": false,
-    "alignWide": true
+    "alignWide": true,
+    "color": {
+      "background": true
+    }
   },
+  -- PREPEND STYLES HERE --
+  -- PREPEND VARIATIONS HERE --
   "acf": {
     "mode": "preview"
   }

--- a/wp-content/themes/wp-starter/plop-templates/parts/css-link.css.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/parts/css-link.css.hbs
@@ -1,2 +1,2 @@
-/*Styles for {{dashCase name}}*/
+/*Styles for {{titleCase name}}*/
 @import '../../blocks/{{dashCase name}}/style.css';

--- a/wp-content/themes/wp-starter/plop-templates/parts/css-link.css.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/parts/css-link.css.hbs
@@ -1,0 +1,2 @@
+/*Styles for {{dashCase name}}*/
+@import '../../blocks/{{dashCase name}}/style.css';

--- a/wp-content/themes/wp-starter/plop-templates/parts/styles.json.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/parts/styles.json.hbs
@@ -1,0 +1,7 @@
+"styles": [
+    {
+      "name": "default",
+      "label": "Default",
+      "isDefault": true
+    }
+  ],

--- a/wp-content/themes/wp-starter/plop-templates/parts/variations.json.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/parts/variations.json.hbs
@@ -1,0 +1,9 @@
+"variations": [
+    {
+      "name": "{{dashCase name}}-variation",
+      "icon": "schedule",
+      "title": "{{titleCase name}} Variation",
+      "scope": ["transform"],
+      "isDefault": true
+    }
+  ],

--- a/wp-content/themes/wp-starter/plop-templates/patterns/{{dashCase name}}-inner-blocks.php.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/patterns/{{dashCase name}}-inner-blocks.php.hbs
@@ -7,3 +7,7 @@
  */
 
 ?>
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->

--- a/wp-content/themes/wp-starter/plop-templates/patterns/{{dashCase name}}-inner-blocks.php.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/patterns/{{dashCase name}}-inner-blocks.php.hbs
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Title: {{titleCase name}}
+ * Slug: {{dashCase themeslug}}/{{dashCase name}}-inner-blocks
+ * Viewport width: 1400
+ * Inserter: no
+ */
+
+?>

--- a/wp-content/themes/wp-starter/plop-templates/render.twig.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/render.twig.hbs
@@ -1,0 +1,26 @@
+{#
+  Block: {{titleCase name}}
+#}
+
+{% set template = [
+	[
+		'core/pattern',
+		{
+			'slug': 'wp-starter/{{dashCase name}}-inner-blocks',
+		}
+	]
+] %}
+
+{% set allowed = [
+	'core/group',
+] %}
+
+{% set inner = {
+	template: template,
+	allowedBlocks: allowed
+} %}
+
+
+<section \{{ block_attrs( attributes ) }}>
+  \{{ inner_blocks( inner ) }}
+</section>

--- a/wp-content/themes/wp-starter/plop-templates/render.twig.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/render.twig.hbs
@@ -11,9 +11,11 @@
 	]
 ] %}
 
+{# If you need to limit what block types are allowed
 {% set allowed = [
 	'core/group',
 ] %}
+#}
 
 {% set inner = {
 	template: template,

--- a/wp-content/themes/wp-starter/plop-templates/render.twig.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/render.twig.hbs
@@ -6,7 +6,7 @@
 	[
 		'core/pattern',
 		{
-			'slug': 'wp-starter/{{dashCase name}}-inner-blocks',
+			'slug': '{{dashCase themeslug}}/{{dashCase name}}-inner-blocks',
 		}
 	]
 ] %}

--- a/wp-content/themes/wp-starter/plop-templates/style.css.hbs
+++ b/wp-content/themes/wp-starter/plop-templates/style.css.hbs
@@ -1,0 +1,5 @@
+@layer components {
+	.acf-block-{{dashCase name}} {
+
+	}
+}

--- a/wp-content/themes/wp-starter/plopfile.js
+++ b/wp-content/themes/wp-starter/plopfile.js
@@ -1,16 +1,4 @@
 module.exports = function (plop) {
-
-	// Block icons from https://developer.wordpress.org/resource/dashicons/
-	const WPIcons = [
-		"default",
-		"align-left",
-		"cover-image",
-		"embed-video",
-		"format-gallery",
-		"layout",
-		"schedule",
-	]
-
 	// Block generator
 	plop.setGenerator('block', {
 		description: 'Set up a new block',
@@ -36,12 +24,6 @@ module.exports = function (plop) {
 					}
 					return "Theme slug is required";
 				  },
-			},
-			{
-				type: 'list',
-				name: 'icon',
-				message: 'Pick a WordPress icon for the block',
-				choices: WPIcons,
 			},
 			{
 				type: 'confirm',
@@ -72,7 +54,7 @@ module.exports = function (plop) {
 				},
 				{
 					type: "append",
-					path: "src/styles/main.css",
+					path: "src/styles/custom-blocks.css",
 					pattern: /\/\*DO NOT REMOVE - Everything below this line is automatically generated\*\//i,
 					templateFile: 'plop-templates/parts/css-link.css.hbs'
 				},

--- a/wp-content/themes/wp-starter/plopfile.js
+++ b/wp-content/themes/wp-starter/plopfile.js
@@ -1,0 +1,19 @@
+module.exports = function (plop) {
+	// controller generator
+	plop.setGenerator('block', {
+		description: 'Set up a new block',
+		prompts: [
+			{
+				type: 'input',
+				name: 'name',
+				message: 'What is the block name?'
+			},
+		],
+		actions: [{
+			type: 'addMany',
+			destination: 'blocks/{{name}}/',
+			base: 'plop-templates',
+			templateFiles: 'plop-templates/*.hbs'
+		}]
+	});
+};

--- a/wp-content/themes/wp-starter/plopfile.js
+++ b/wp-content/themes/wp-starter/plopfile.js
@@ -6,14 +6,68 @@ module.exports = function (plop) {
 			{
 				type: 'input',
 				name: 'name',
-				message: 'What is the block name?'
+				message: 'What is the block name?',
+				validate: function (value) {
+					if (/.+/.test(value)) {
+					  return true;
+					}
+					return "Name is required";
+				  },
 			},
+			{
+				type: 'confirm',
+				name: 'styles',
+				message: 'Do you want block styles?'
+			},
+			{
+				type: 'confirm',
+				name: 'variations',
+				message: 'Do you want block variations?'
+			}
 		],
-		actions: [{
-			type: 'addMany',
-			destination: 'blocks/{{name}}/',
-			base: 'plop-templates',
-			templateFiles: 'plop-templates/*.hbs'
-		}]
+		actions: function(data) {
+			var actions = [{
+				type: 'addMany',
+				destination: 'blocks/{{dashCase name}}/',
+				base: 'plop-templates',
+				templateFiles: 'plop-templates/*.hbs',
+				abortOnFail: true,
+			}];
+
+			// add styles
+			if (data.styles) {
+				actions.push({
+					type: 'modify',
+					path: 'blocks/{{dashCase name}}/block.json',
+					pattern: /-- PREPEND STYLES HERE --/gi,
+					templateFile: 'plop-templates/parts/styles.json.hbs'
+				});
+			} else {
+				actions.push({
+					type: 'modify',
+					path: 'blocks/{{dashCase name}}/block.json',
+					pattern: /-- PREPEND STYLES HERE --/gi
+				});
+			}
+
+			// add styles
+			if (data.styles) {
+				actions.push({
+					type: 'modify',
+					path: 'blocks/{{dashCase name}}/block.json',
+					pattern: /-- PREPEND VARIATIONS HERE --/gi,
+					templateFile: 'plop-templates/parts/variations.json.hbs'
+				});
+			} else {
+				actions.push({
+					type: 'modify',
+					path: 'blocks/{{dashCase name}}/block.json',
+					pattern: /-- PREPEND VARIATIONS HERE --/gi
+				});
+			}
+
+
+            return actions;
+        }
 	});
 };

--- a/wp-content/themes/wp-starter/plopfile.js
+++ b/wp-content/themes/wp-starter/plopfile.js
@@ -55,7 +55,7 @@ module.exports = function (plop) {
 				{
 					type: "append",
 					path: "src/styles/main.css",
-					pattern: /\/\*Everything below this line is automatically generated DO NOT REMOVE\*\//i,
+					pattern: /\/\*DO NOT REMOVE Everything below this line is automatically generated\*\//i,
 					templateFile: 'plop-templates/parts/css-link.css.hbs'
 				},
 			];
@@ -65,14 +65,15 @@ module.exports = function (plop) {
 				actions.push({
 					type: 'modify',
 					path: 'blocks/{{dashCase name}}/block.json',
-					pattern: /-- PREPEND STYLES HERE --/gi,
+					pattern: /-- STYLES HERE --/gi,
 					templateFile: 'plop-templates/parts/styles.json.hbs'
 				});
 			} else {
+				// if no styles remove prepend text
 				actions.push({
 					type: 'modify',
 					path: 'blocks/{{dashCase name}}/block.json',
-					pattern: /-- PREPEND STYLES HERE --/gi
+					pattern: /-- STYLES HERE --/gi
 				});
 			}
 
@@ -81,14 +82,14 @@ module.exports = function (plop) {
 				actions.push({
 					type: 'modify',
 					path: 'blocks/{{dashCase name}}/block.json',
-					pattern: /-- PREPEND VARIATIONS HERE --/gi,
+					pattern: /-- VARIATIONS HERE --/gi,
 					templateFile: 'plop-templates/parts/variations.json.hbs'
 				});
 			} else {
 				actions.push({
 					type: 'modify',
 					path: 'blocks/{{dashCase name}}/block.json',
-					pattern: /-- PREPEND VARIATIONS HERE --/gi
+					pattern: /-- VARIATIONS HERE --/gi
 				});
 			}
 

--- a/wp-content/themes/wp-starter/plopfile.js
+++ b/wp-content/themes/wp-starter/plopfile.js
@@ -1,5 +1,17 @@
 module.exports = function (plop) {
-	// controller generator
+
+	// Block icons from https://developer.wordpress.org/resource/dashicons/
+	const WPIcons = [
+		"default",
+		"align-left",
+		"cover-image",
+		"embed-video",
+		"format-gallery",
+		"layout",
+		"schedule",
+	]
+
+	// Block generator
 	plop.setGenerator('block', {
 		description: 'Set up a new block',
 		prompts: [
@@ -15,24 +27,38 @@ module.exports = function (plop) {
 				  },
 			},
 			{
+				type: 'list',
+				name: 'icon',
+				message: 'Pick an WordPress icon for the block',
+				choices: WPIcons,
+			},
+			{
 				type: 'confirm',
 				name: 'styles',
-				message: 'Do you want block styles?'
+				message: 'Do you need block styles?'
 			},
 			{
 				type: 'confirm',
 				name: 'variations',
-				message: 'Do you want block variations?'
+				message: 'Do you need block variations?'
 			}
 		],
 		actions: function(data) {
-			var actions = [{
-				type: 'addMany',
-				destination: 'blocks/{{dashCase name}}/',
-				base: 'plop-templates',
-				templateFiles: 'plop-templates/*.hbs',
-				abortOnFail: true,
-			}];
+			var actions = [
+				{
+					type: 'addMany',
+					destination: 'blocks/{{dashCase name}}/',
+					base: 'plop-templates',
+					templateFiles: 'plop-templates/*.hbs',
+					abortOnFail: true,
+				},
+				{
+					type: "append",
+					path: "src/styles/main.css",
+					pattern: /\/\*Everything below this line is automatically generated DO NOT REMOVE\*\//i,
+					templateFile: 'plop-templates/parts/css-link.css.hbs'
+				},
+			];
 
 			// add styles
 			if (data.styles) {
@@ -50,7 +76,7 @@ module.exports = function (plop) {
 				});
 			}
 
-			// add styles
+			// add variations
 			if (data.styles) {
 				actions.push({
 					type: 'modify',

--- a/wp-content/themes/wp-starter/plopfile.js
+++ b/wp-content/themes/wp-starter/plopfile.js
@@ -27,9 +27,20 @@ module.exports = function (plop) {
 				  },
 			},
 			{
+				type: 'input',
+				name: 'themeslug',
+				message: 'What is the slug for your theme?',
+				validate: function (value) {
+					if (/.+/.test(value)) {
+					  return true;
+					}
+					return "Theme slug is required";
+				  },
+			},
+			{
 				type: 'list',
 				name: 'icon',
-				message: 'Pick an WordPress icon for the block',
+				message: 'Pick a WordPress icon for the block',
 				choices: WPIcons,
 			},
 			{
@@ -41,7 +52,7 @@ module.exports = function (plop) {
 				type: 'confirm',
 				name: 'variations',
 				message: 'Do you need block variations?'
-			}
+			},
 		],
 		actions: function(data) {
 			var actions = [
@@ -53,9 +64,16 @@ module.exports = function (plop) {
 					abortOnFail: true,
 				},
 				{
+					type: 'addMany',
+					destination: 'blocks/{{dashCase name}}/',
+					base: 'plop-templates',
+					templateFiles: 'plop-templates/patterns/*.hbs',
+					abortOnFail: true,
+				},
+				{
 					type: "append",
 					path: "src/styles/main.css",
-					pattern: /\/\*DO NOT REMOVE Everything below this line is automatically generated\*\//i,
+					pattern: /\/\*DO NOT REMOVE - Everything below this line is automatically generated\*\//i,
 					templateFile: 'plop-templates/parts/css-link.css.hbs'
 				},
 			];

--- a/wp-content/themes/wp-starter/src/styles/custom-blocks.css
+++ b/wp-content/themes/wp-starter/src/styles/custom-blocks.css
@@ -1,0 +1,1 @@
+/*DO NOT REMOVE - Everything below this line is automatically generated*/

--- a/wp-content/themes/wp-starter/src/styles/main.css
+++ b/wp-content/themes/wp-starter/src/styles/main.css
@@ -22,3 +22,5 @@
 @import '../../blocks/text-image/style.css';
 @import '../../blocks/text-icon-cards/style.css';
 @import '../../blocks/video-embed/style.css';
+
+/*Everything below this line is automatically generated DO NOT REMOVE*/

--- a/wp-content/themes/wp-starter/src/styles/main.css
+++ b/wp-content/themes/wp-starter/src/styles/main.css
@@ -23,4 +23,4 @@
 @import '../../blocks/text-icon-cards/style.css';
 @import '../../blocks/video-embed/style.css';
 
-/*DO NOT REMOVE Everything below this line is automatically generated*/
+/*DO NOT REMOVE - Everything below this line is automatically generated*/

--- a/wp-content/themes/wp-starter/src/styles/main.css
+++ b/wp-content/themes/wp-starter/src/styles/main.css
@@ -13,7 +13,7 @@
 @import './core-blocks/navigation.css';
 @import './core-blocks/quote.css';
 
-/*Import custom styles for custom blocks*/
+/*Import custom styles for main theme blocks*/
 @import '../../blocks/accordion/style.css';
 @import '../../blocks/alert-banner/style.css';
 @import '../../blocks/breadcrumbs/style.css';
@@ -23,4 +23,5 @@
 @import '../../blocks/text-icon-cards/style.css';
 @import '../../blocks/video-embed/style.css';
 
-/*DO NOT REMOVE - Everything below this line is automatically generated*/
+/*Import styles for custom blocks*/
+@import './custom-blocks.css';

--- a/wp-content/themes/wp-starter/src/styles/main.css
+++ b/wp-content/themes/wp-starter/src/styles/main.css
@@ -23,4 +23,4 @@
 @import '../../blocks/text-icon-cards/style.css';
 @import '../../blocks/video-embed/style.css';
 
-/*Everything below this line is automatically generated DO NOT REMOVE*/
+/*DO NOT REMOVE Everything below this line is automatically generated*/


### PR DESCRIPTION
# Summary

This adds [plop](https://plopjs.com/) which allows us to auto build block files from the templates. We ask several questions and then build all the files. 

## Issues

* #129

## Testing Instructions

1. Restart DDEV by running `ddev restart`
2. Then path into the theme `wp-content/themes/wp-starter`
3. Run `ddev npm run plop block` or `ddev npm run plop` - running without  `block` plop will default to the first generator which is `block`. 

## Screenshots
![Jul-24-2024 15-15-48](https://github.com/user-attachments/assets/2b86eadb-e31f-481a-9e33-1aea3e162dec)


