### PR TITLE
[#126] Adding the plugin accessibility-checker to our default build

### DIFF
--- a/bin/composer-scripts/ProjectEvents/PostInstallScript.php
+++ b/bin/composer-scripts/ProjectEvents/PostInstallScript.php
@@ -54,6 +54,7 @@ class PostInstallScript extends ComposerScript {
 	 * @var array
 	 */
 	private static array $activatePlugins = [
+		'accessibility-checker' => 'Accessibility Checker',
 		'acf-blocks-toolkit' => [
 			'name' => 'ACF Blocks Toolkit',
 			'dependencies' => [

--- a/wp-content/themes/wp-starter/composer.json
+++ b/wp-content/themes/wp-starter/composer.json
@@ -28,6 +28,7 @@
     "idleberg/wordpress-vite-assets": "^1.0",
     "squizlabs/php_codesniffer": "^3.9",
     "timber/timber": "^2.1",
+    "wpackagist-plugin/accessibility-checker": "^1.15",
     "wpackagist-plugin/seo-by-rank-math": "^1.0",
     "wpackagist-plugin/svg-support": "^2.5",
     "wpackagist-plugin/wordfence": "^7.11"

--- a/wp-content/themes/wp-starter/composer.lock
+++ b/wp-content/themes/wp-starter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca51503320aff9bc3e43346550fc129f",
+    "content-hash": "30d74b11b0da5ffa76774b0fad5c26aa",
     "packages": [
         {
             "name": "composer/installers",
@@ -1066,6 +1066,24 @@
                 }
             ],
             "time": "2024-04-18T11:59:33+00:00"
+        },
+        {
+            "name": "wpackagist-plugin/accessibility-checker",
+            "version": "1.15.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/accessibility-checker/",
+                "reference": "tags/1.15.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/accessibility-checker.1.15.0.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/accessibility-checker/"
         },
         {
             "name": "wpackagist-plugin/seo-by-rank-math",


### PR DESCRIPTION
# Summary

Adding the [Accessibility Checker](https://equalizedigital.com/) plugin. We found this plugin on GoodBids and the plugins checks the page like the WAVE tool but in the WP page editor. Helps our team when running QA/a11y and helps our clients keep the site accessible. 

## Issues

* #126

## Testing Instructions

1. My need to re-run composer
2. Once this is merged we will test new build and make sure the plugin is added. 

## Screenshots

<img width="936" alt="Screenshot 2024-07-26 at 1 22 19 PM" src="https://github.com/user-attachments/assets/97eaecd9-1d39-4d5e-a641-551e921cc5d7">

