### PR TITLE
[N/A] ACF Blocks Toolkit Changes from Block Forms branch

### DIFF
--- a/wp-content/plugins/acf-blocks-toolkit/src/classes/BlockRegistration.php
+++ b/wp-content/plugins/acf-blocks-toolkit/src/classes/BlockRegistration.php
@@ -455,7 +455,7 @@ class BlockRegistration {
 
 		if ( ! in_array( $block_id, self::$block_ids, true ) ) {
 			self::$block_ids[] = $block_id;
-			set_transient( self::BLOCK_IDS_TRANSIENT, self::$block_ids, 4 );
+			set_transient( self::BLOCK_IDS_TRANSIENT, self::$block_ids, 1 );
 		}
 	}
 

--- a/wp-content/themes/wp-starter/blocks/accordion/render.twig
+++ b/wp-content/themes/wp-starter/blocks/accordion/render.twig
@@ -17,6 +17,6 @@
 	template: template,
 	allowedBlocks: allowed
 } %}
-<section {{ block_attrs( attributes ) }}>
+<section {{ block_attrs( block ) }}>
   {{ inner_blocks( inner ) }}
 </section>

--- a/wp-content/themes/wp-starter/blocks/alert-banner/render.twig
+++ b/wp-content/themes/wp-starter/blocks/alert-banner/render.twig
@@ -23,15 +23,15 @@ Block: Alert Banner
 
 {% if function('is_admin') == false %}
 	{% set attrs = {
-		'x-data': '{ ' ~ attributes.id ~ ': $persist(true) }',
-		'x-show': attributes.id
+		'x-data': '{ ' ~ block.id ~ ': $persist(true) }',
+		'x-show': block.id
 	} %}
 {% endif %}
 <section
-	{{ block_attrs( attributes, 'gap-24 lg:gap-48', attrs ) }}
+	{{ block_attrs( block, 'gap-24 lg:gap-48', attrs ) }}
 >
 	<div class="flex flex-col items-start gap-24 lg:flex-row lg:gap-48 lg:items-center">
 		{{ inner_blocks( inner ) }}
 	</div>
-	{{ function( 'alert_banner_dismiss_button', attributes.id ) }}
+	{{ function( 'alert_banner_dismiss_button', block.id ) }}
 </section>

--- a/wp-content/themes/wp-starter/blocks/breadcrumbs/render.twig
+++ b/wp-content/themes/wp-starter/blocks/breadcrumbs/render.twig
@@ -2,6 +2,6 @@
   Block: Breadcrumbs
 #}
 
-<section {{ block_attrs( attributes ) }}>
+<section {{ block_attrs( block ) }}>
   {{ function( 'wpstarter_breadcrumbs' ) }}
 </section>

--- a/wp-content/themes/wp-starter/blocks/cta/render.twig
+++ b/wp-content/themes/wp-starter/blocks/cta/render.twig
@@ -11,7 +11,7 @@
   ]
 ] %}
 {% set inner = { template: template } %}
-<section {{ block_attrs( attributes, "flex flex-col gap-24 mx-auto p-24 lg:p-64" ) }}>
+<section {{ block_attrs( block, "flex flex-col gap-24 mx-auto p-24 lg:p-64" ) }}>
 	<div class="flex flex-col gap-8 flex-1">
 		{{ inner_blocks( inner ) }}
 	</div>

--- a/wp-content/themes/wp-starter/blocks/image-caption/render.twig
+++ b/wp-content/themes/wp-starter/blocks/image-caption/render.twig
@@ -11,6 +11,6 @@
 	allowedBlocks: allowed,
 	templateLock: 'all'
 } %}
-<section {{ block_attrs( attributes ) }}>
+<section {{ block_attrs( block ) }}>
   {{ inner_blocks( inner ) }}
 </section>

--- a/wp-content/themes/wp-starter/blocks/logo-grid/render.twig
+++ b/wp-content/themes/wp-starter/blocks/logo-grid/render.twig
@@ -12,6 +12,6 @@
 	template: template,
 	allowedBlocks: allowed,
 } %}
-<section {{ block_attrs( attributes ) }}>
+<section {{ block_attrs( block ) }}>
   {{ inner_blocks( inner ) }}
 </section>

--- a/wp-content/themes/wp-starter/blocks/navigation-container/render.twig
+++ b/wp-content/themes/wp-starter/blocks/navigation-container/render.twig
@@ -26,7 +26,7 @@
 	} %}
 {% endif %}
 
-<div {{ block_attrs( attributes, 'wp-block-group navigation-container flex flex-col items-end gap-5 md:w-auto w-full', attrs ) }}>
+<div {{ block_attrs( block, 'wp-block-group navigation-container flex flex-col items-end gap-5 md:w-auto w-full', attrs ) }}>
 	<button
 		{% if function('is_admin') == false %}
 			@click="menuIsOpen = !menuIsOpen"

--- a/wp-content/themes/wp-starter/blocks/page-header/render.twig
+++ b/wp-content/themes/wp-starter/blocks/page-header/render.twig
@@ -11,6 +11,6 @@
   ]
 ] %}
 {% set inner = { template: template } %}
-<section {{ block_attrs( attributes ) }}>
+<section {{ block_attrs( block ) }}>
 	{{ inner_blocks( inner ) }}
 </section>

--- a/wp-content/themes/wp-starter/blocks/text-icon-cards/render.twig
+++ b/wp-content/themes/wp-starter/blocks/text-icon-cards/render.twig
@@ -12,6 +12,6 @@
 	template: template,
 	allowedBlocks: allowed,
 } %}
-<section {{ block_attrs( attributes ) }}>
+<section {{ block_attrs( block ) }}>
   {{ inner_blocks( inner ) }}
 </section>

--- a/wp-content/themes/wp-starter/blocks/text-icon-cards/text-icon-card/render.twig
+++ b/wp-content/themes/wp-starter/blocks/text-icon-cards/text-icon-card/render.twig
@@ -11,6 +11,6 @@
   ]
 ] %}
 {% set inner = { template: template } %}
-<article {{ block_attrs( attributes ) }}>
+<article {{ block_attrs( block ) }}>
   {{ inner_blocks( inner ) }}
 </article>

--- a/wp-content/themes/wp-starter/blocks/text-image/render.twig
+++ b/wp-content/themes/wp-starter/blocks/text-image/render.twig
@@ -20,6 +20,6 @@
 	template: template,
 	allowedBlocks: allowed
 } %}
-<section {{ block_attrs( attributes ) }}>
+<section {{ block_attrs( block ) }}>
   {{ inner_blocks( inner ) }}
 </section>

--- a/wp-content/themes/wp-starter/blocks/video-embed/render.twig
+++ b/wp-content/themes/wp-starter/blocks/video-embed/render.twig
@@ -19,6 +19,6 @@
 	template: template,
 	allowedBlocks: allowed
 } %}
-<section {{ block_attrs( attributes ) }}>
+<section {{ block_attrs( block ) }}>
   {{ inner_blocks( inner ) }}
 </section>


### PR DESCRIPTION
# Summary

This PR contains changes made to the ACF Blocks Toolkit plugin during the development of ACF Form Blocks plugin.

## Summary of Changes

* Adds support for Unique Persistent Block IDs
* Slight refactor of `block_attrs()` to be cleaner and more consistent
* Allows block templates (inner blocks) to be specified in the `block.json` file under the `"acf"` object, accessible from `$block['template']`.
* Provides additional helpful variables to the `render.php` (and `render.twig`), as well as renames `attributes` to `block` to be more consistent with the PHP template.
  * `int $post_id`
  * `WP_Block $wp_block`
  * `array|bool $context` (usually array)
  * `bool $is_ajax_render`

## Issues

* N/A
