### PR TITLE
[#141] Fixing css/js bugs with preview and console log

### DIFF
--- a/wp-content/plugins/acf-blocks-toolkit/includes/helpers.php
+++ b/wp-content/plugins/acf-blocks-toolkit/includes/helpers.php
@@ -77,10 +77,6 @@ if ( ! function_exists( 'block_attrs' ) ) {
 
 		do_action( 'acfbt_block_attr', $block );
 
-		if ( is_preview() ) {
-			return;
-		}
-
 		echo wp_kses_data( get_block_wrapper_attributes( $extra ) );
 	}
 }

--- a/wp-content/themes/wp-starter/inc/class-vite.php
+++ b/wp-content/themes/wp-starter/inc/class-vite.php
@@ -64,13 +64,13 @@ class Vite {
 
 		$this->env = getenv( 'ENVIRONMENT' );
 
-		//set frontend css/js
+		// set frontend css/js
 		$this->entries['default'] = 'main.js';
 
-		//set editor css/js
-		$this->entries['editor']  = 'main.js';
+		// set editor css/js
+		$this->entries['editor'] = 'main.js';
 
-		add_action( 'wp_head', [ $this, 'init' ] );
+		add_action( 'wp_head', [ $this, 'init' ], 100 );
 
 		add_action(
 			'admin_head',
@@ -455,5 +455,3 @@ class Vite {
 		}
 	}
 }
-
-new Vite();


### PR DESCRIPTION
# Summary

Fixes the css missing in preview mode.
Removes the duplicate Vite call. 
Adds our custom css/js at the vary bottom of the `head` tag which fixes the `importmap` error

## Issues

* #141

## Testing Instructions

1. Make sure there is no `importmap` error in the console.
2. If you view a page in Preview the styles look the same.

## Screenshots

NA
