### PR TITLE
[N/A] SVG Support Removal

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -78,7 +78,7 @@ jobs:
             sudo rm -rf ${{ secrets.APP_PATH }}/wp-content/mu-plugins/viget-wp &&\
             sudo rm -rf ${{ secrets.APP_PATH }}/wp-content/mu-plugins/viget-wp.php &&\
             sudo rm -rf ${{ secrets.APP_PATH }}/wp-content/plugins/acf-blocks-toolkit &&\
-            sudo rm -rf ${{ secrets.APP_PATH }}/wp-content/plugins/svg-support &&\
+            sudo rm -rf ${{ secrets.APP_PATH }}/wp-content/plugins/safe-svg &&\
             sudo rm -rf ${{ secrets.APP_PATH }}/wp-content/plugins/advanced-custom-fields-pro"
           rsync -rlptzv --exclude="node_modules" ./wp-content/ ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_TARGET }}:${{ secrets.APP_PATH }}/wp-content/
           ssh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_TARGET }} "\
@@ -92,7 +92,7 @@ jobs:
             sudo rm -rf ${{ secrets.APP_PATH }}/wp-content/mu-plugins/viget-wp &&\
             sudo rm -rf ${{ secrets.APP_PATH }}/wp-content/mu-plugins/viget-wp.php &&\
             sudo rm -rf ${{ secrets.APP_PATH }}/wp-content/plugins/acf-blocks-toolkit &&\
-            sudo rm -rf ${{ secrets.APP_PATH }}/wp-content/plugins/svg-support &&\
+            sudo rm -rf ${{ secrets.APP_PATH }}/wp-content/plugins/safe-svg &&\
             sudo rm -rf ${{ secrets.APP_PATH }}/wp-content/plugins/advanced-custom-fields-pro"
           rsync -rlptzv --exclude="node_modules" ./wp-content/ ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_KIT_TARGET }}:${{ secrets.APP_PATH }}/wp-content/
           ssh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_KIT_TARGET }} "\

--- a/bin/composer-scripts/ProjectEvents/PostCreateProjectScript.php
+++ b/bin/composer-scripts/ProjectEvents/PostCreateProjectScript.php
@@ -501,6 +501,9 @@ class PostCreateProjectScript extends ComposerScript {
 		// Remove site-starter vendor files
 		self::removeRootVendorDir();
 
+		// Remove site-starter deployment integration.
+		self::removeDeployment();
+
 		self::writeInfo( 'Self-destruction complete.' );
 	}
 
@@ -522,5 +525,25 @@ class PostCreateProjectScript extends ComposerScript {
 		self::deleteDirectory( $vendorDir );
 
 		self::writeInfo( 'Root vendor directory removed.' );
+	}
+
+	/**
+	 * Remove the deployment script.
+	 *
+	 * @return void
+	 */
+	private static function removeDeployment(): void {
+		self::writeLine( 'Removing deployment script...' );
+
+		$deployFile = self::translatePath( '.github/workflows/deploy.yaml' );
+
+		if ( ! file_exists( $deployFile ) ) {
+			self::writeWarning( 'Deployment script not found. Skipping removal.' );
+			return;
+		}
+
+		unlink( $deployFile );
+
+		self::writeInfo( 'Deployment script removed.' );
 	}
 }

--- a/bin/composer-scripts/ProjectEvents/PostCreateProjectScript.php
+++ b/bin/composer-scripts/ProjectEvents/PostCreateProjectScript.php
@@ -501,8 +501,8 @@ class PostCreateProjectScript extends ComposerScript {
 		// Remove site-starter vendor files
 		self::removeRootVendorDir();
 
-		// Remove site-starter deployment integration.
-		self::removeDeployment();
+		// Remove site-starter related Github integrated files.
+		self::removeGithubFiles();
 
 		self::writeInfo( 'Self-destruction complete.' );
 	}
@@ -532,18 +532,27 @@ class PostCreateProjectScript extends ComposerScript {
 	 *
 	 * @return void
 	 */
-	private static function removeDeployment(): void {
-		self::writeLine( 'Removing deployment script...' );
+	private static function removeGithubFiles(): void {
+		self::writeLine( 'Removing GitHub integration files...' );
 
 		$deployFile = self::translatePath( '.github/workflows/deploy.yaml' );
 
 		if ( ! file_exists( $deployFile ) ) {
 			self::writeWarning( 'Deployment script not found. Skipping removal.' );
-			return;
+		} else {
+			unlink( $deployFile );
+			self::writeInfo( 'Deployment script removed.' );
 		}
 
-		unlink( $deployFile );
+		$componentTemplate = self::translatePath( '.github/ISSUE_TEMPLARTE/new-component-ticket.md' );
 
-		self::writeInfo( 'Deployment script removed.' );
+		if ( ! file_exists( $componentTemplate ) ) {
+			self::writeWarning( 'Component Issue template not found. Skipping removal.' );
+		} else {
+			unlink( $componentTemplate );
+			self::writeInfo( 'Component Issue template removed.' );
+		}
+
+
 	}
 }

--- a/bin/composer-scripts/ProjectEvents/PostInstallScript.php
+++ b/bin/composer-scripts/ProjectEvents/PostInstallScript.php
@@ -62,9 +62,8 @@ class PostInstallScript extends ComposerScript {
 			],
 		],
 		'seo-by-rank-math' => 'Rank Math SEO',
-		'svg-support' => 'SVG Support',
+		'safe-svg' => 'Safe SVG',
 		'viget-parts-kit' => 'Viget Parts Kit',
-		'wordfence' => 'Wordfence',
 	];
 
 	/**

--- a/wp-content/themes/wp-starter/composer.json
+++ b/wp-content/themes/wp-starter/composer.json
@@ -29,8 +29,8 @@
     "squizlabs/php_codesniffer": "^3.9",
     "timber/timber": "^2.1",
     "wpackagist-plugin/accessibility-checker": "^1.15",
+    "wpackagist-plugin/safe-svg": "^2.2",
     "wpackagist-plugin/seo-by-rank-math": "^1.0",
-    "wpackagist-plugin/svg-support": "^2.5",
     "wpackagist-plugin/wordfence": "^7.11"
   },
   "require-dev": {

--- a/wp-content/themes/wp-starter/composer.lock
+++ b/wp-content/themes/wp-starter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "30d74b11b0da5ffa76774b0fad5c26aa",
+    "content-hash": "3b63970dc27be0142c2ad3f03e20ce01",
     "packages": [
         {
             "name": "composer/installers",
@@ -1086,6 +1086,24 @@
             "homepage": "https://wordpress.org/plugins/accessibility-checker/"
         },
         {
+            "name": "wpackagist-plugin/safe-svg",
+            "version": "2.2.6",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/safe-svg/",
+                "reference": "tags/2.2.6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/safe-svg.2.2.6.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/safe-svg/"
+        },
+        {
             "name": "wpackagist-plugin/seo-by-rank-math",
             "version": "1.0.219",
             "source": {
@@ -1102,24 +1120,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/seo-by-rank-math/"
-        },
-        {
-            "name": "wpackagist-plugin/svg-support",
-            "version": "2.5.5",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/svg-support/",
-                "reference": "tags/2.5.5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/svg-support.2.5.5.zip"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/svg-support/"
         },
         {
             "name": "wpackagist-plugin/wordfence",

--- a/wp-content/themes/wp-starter/readme.txt
+++ b/wp-content/themes/wp-starter/readme.txt
@@ -24,6 +24,6 @@ text by Smarty from <a href="https://thenounproject.com/browse/icons/term/text/"
 
 == Recommended Plugins ==
 
-SVG Support
-https://wordpress.org/plugins/svg-support/
+Safe SVG
+https://wordpress.org/plugins/safe-svg/
 Safely upload SVGs


### PR DESCRIPTION
# Summary

This PR eradicates SVG Support and replaces it with Safe SVG. This was supposed to be in the last PR, however, something weird happened with the `composer` file (maybe a bad merge), and it still remained.

## Issues

I just realized some of this work is duplicated in [this PR](https://github.com/vigetlabs/wordpress-site-starter/pull/153), but this solution is a bit more robust, and cleans up some WP Site Starter specific GitHub files.

## Testing Instructions

1. On a fresh install, the Safe SVG plugin should be included, not SVG Support.
