### PR TITLE
[N/A] Disable Composer Script if not in Dev Mode

### DIFF
--- a/bin/composer-scripts/ProjectEvents/PostCreateProjectScript.php
+++ b/bin/composer-scripts/ProjectEvents/PostCreateProjectScript.php
@@ -43,6 +43,11 @@ class PostCreateProjectScript extends ComposerScript {
 	public static function execute( Event $event ): void {
 		self::setEvent( $event );
 
+		// Do not run on deployment.
+		if ( ! $event->isDevMode() ) {
+			return;
+		}
+
 		if ( ! self::needsSetup() ) {
 			return;
 		}

--- a/bin/composer-scripts/ProjectEvents/PostInstallScript.php
+++ b/bin/composer-scripts/ProjectEvents/PostInstallScript.php
@@ -78,6 +78,11 @@ class PostInstallScript extends ComposerScript {
 	public static function init( Event $event, bool $fromExecute = false ): void {
 		self::setEvent( $event );
 
+		// Do not run on deployment.
+		if ( ! $event->isDevMode() ) {
+			return;
+		}
+
 		// Load DDEV Environment variables.
 		self::loadDDEVEnvironmentVars();
 


### PR DESCRIPTION
# Summary

This prevents the `composer` scripts from running unless in Dev Mode.

## Issues

* N/A

## Testing Instructions

1. Run a deployment
2. Hopefully everything deploys.
