### PR TITLE
[N/A] Allow Core Search block in Navigation Container

### DIFF
--- a/wp-content/themes/wp-starter/blocks/navigation-container/render.php
+++ b/wp-content/themes/wp-starter/blocks/navigation-container/render.php
@@ -17,6 +17,7 @@ $allowed = [
 	'core/paragraph',
 	'core/button',
 	'core/navigation',
+	'core/search',
 ];
 
 $block_template = [

--- a/wp-content/themes/wp-starter/blocks/navigation-container/render.twig
+++ b/wp-content/themes/wp-starter/blocks/navigation-container/render.twig
@@ -10,7 +10,8 @@
 	'core/group',
 	'core/paragraph',
 	'core/button',
-	'core/navigation'
+	'core/navigation',
+	'core/search'
 ] %}
 {% set inner = {
 	template: template,


### PR DESCRIPTION
# Summary

This PR allows the Core Search block to be added to the Navigation Container block.

## Issues

* N/A

## Testing Instructions

1. Try to add the Search block as a child of the Navigation Container block.
