### PR TITLE
[N/A] Add Custom Scripts Tools Page

### DIFF
--- a/wp-content/mu-plugins/viget-wp.php
+++ b/wp-content/mu-plugins/viget-wp.php
@@ -3,7 +3,7 @@
  * Plugin Name: Viget WP
  * Plugin URI: https://github.com/vigetlabs/viget-wp
  * Description: WordPress Customization from Viget
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Viget
  * Author URI: https://www.viget.com/
  * Text Domain: viget-wp

--- a/wp-content/mu-plugins/viget-wp/.editorconfig
+++ b/wp-content/mu-plugins/viget-wp/.editorconfig
@@ -1,0 +1,27 @@
+# This file is for unifying the coding style for different editors and IDEs
+# It is based on https://core.trac.wordpress.org/browser/trunk/.editorconfig
+# See https://editorconfig.org for more information about the standard.
+# WordPress VIP documentation: https://docs.wpvip.com/technical-references/vip-codebase/editorconfig/
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 4
+
+[{*.yml,*.json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.txt]
+end_of_line = crlf

--- a/wp-content/mu-plugins/viget-wp/README.md
+++ b/wp-content/mu-plugins/viget-wp/README.md
@@ -5,6 +5,7 @@ This plugin is a collection of custom functionality for WordPress sites. It is i
 ## Features
 
 * **`dd()` Debug Function**: A helper function to dump and (optionally) die.
+* **Custom Scripts**: Add custom scripts to the WordPress Admin that will output in the `<head>` and `<body>`.
 * **Disable Comments**: Disable comments on all post types and any comment-related blocks.
 * **Gravatar support for `+` email addresses**: Allow Gravatar to work with email addresses that contain a `+` symbol.
 * **ACF + Gravity Forms Integration**: Automatically populate fields named `gravity_form` with available forms.

--- a/wp-content/mu-plugins/viget-wp/src/assets/css/admin.css
+++ b/wp-content/mu-plugins/viget-wp/src/assets/css/admin.css
@@ -10,3 +10,11 @@
 body.options-discussion-php form table:first-of-type {
 	display: none;
 }
+
+/* Custom CodeMirror Theme */
+.cm-s-oceanic-next.CodeMirror {
+	background-color: #122c3a;
+}
+.cm-s-oceanic-next .CodeMirror-gutters {
+	background-color: #1a4155;
+}

--- a/wp-content/mu-plugins/viget-wp/src/assets/js/custom-scripts.js
+++ b/wp-content/mu-plugins/viget-wp/src/assets/js/custom-scripts.js
@@ -1,0 +1,15 @@
+/**
+ * Custom scripts
+ */
+
+document.addEventListener('DOMContentLoaded', function() {
+    const textareas = document.querySelectorAll('.wp-code-mirror');
+    textareas.forEach(function(textarea) {
+        wp.CodeMirror.fromTextArea(textarea, {
+            lineNumbers: true,
+            mode: 'htmlmixed',
+            theme: 'tomorrow-night-eighties',
+            lineWrapping: true
+        });
+    });
+});

--- a/wp-content/mu-plugins/viget-wp/src/assets/js/custom-scripts.js
+++ b/wp-content/mu-plugins/viget-wp/src/assets/js/custom-scripts.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
         wp.CodeMirror.fromTextArea(textarea, {
             lineNumbers: true,
             mode: 'htmlmixed',
-            theme: 'tomorrow-night-eighties',
+            theme: 'oceanic-next',
             lineWrapping: true
         });
     });

--- a/wp-content/mu-plugins/viget-wp/src/classes/Admin/CustomScripts.php
+++ b/wp-content/mu-plugins/viget-wp/src/classes/Admin/CustomScripts.php
@@ -1,0 +1,325 @@
+<?php
+/**
+ * Custom Scripts
+ *
+ * @package VigetWP
+ */
+
+namespace VigetWP\Admin;
+
+/**
+ * Custom Scripts
+ */
+class CustomScripts {
+
+	/**
+	 * Option name
+	 *
+	 * @var string
+	 */
+	const OPTION_NAME = 'vigetwp_custom_scripts';
+
+	/**
+	 * Page Slug
+	 *
+	 * @var string
+	 */
+	const PAGE_SLUG = 'vigetwp-custom-scripts';
+
+	/**
+	 * Custom scripts
+	 *
+	 * @var array
+	 */
+	private array $scripts = [
+		'head_open'  => '',
+		'head_close' => '',
+		'body_open'  => '',
+		'body_close' => '',
+	];
+
+	/**
+	 * CustomScripts constructor.
+	 */
+	public function __construct() {
+		// Load custom scripts
+		$this->load_scripts();
+
+		// Save Custom Scripts settings
+		$this->save_settings();
+
+		// Add custom scripts to the Tools menu
+		$this->scripts_menu();
+
+		// Register Custom Scripts settings
+		$this->register_settings();
+
+		// Enqueue admin assets for the Custom Scripts page
+		$this->enqueue_admin_assets();
+
+		// Insert custom scripts
+		$this->insert_scripts();
+	}
+
+	/**
+	 * Load custom scripts
+	 *
+	 * @return void
+	 */
+	private function load_scripts(): void {
+		$scripts = get_option( self::OPTION_NAME );
+		if ( ! $scripts ) {
+			return;
+		}
+
+		$this->scripts = $scripts;
+	}
+
+	/**
+	 * Get custom scripts
+	 *
+	 * @param ?string $location Location of the script.
+	 *
+	 * @return string|array
+	 */
+	public function get_scripts( ?string $location = null ): string|array {
+		if ( ! $location ) {
+			return $this->scripts;
+		}
+
+		return $this->scripts[ $location ];
+	}
+
+	/**
+	 * Register Custom Scripts settings
+	 *
+	 * @return void
+	 */
+	private function register_settings(): void {
+		add_action(
+			'admin_init',
+			function() {
+				register_setting( 'vigetwp_head_scripts', self::OPTION_NAME );
+
+				add_settings_section(
+					'vigetwp_head_scripts',
+					__( 'Head Scripts', 'viget-wp' ),
+					'__return_empty_string',
+					self::OPTION_NAME
+				);
+
+				add_settings_field(
+					'vigetwp_head_open_scripts',
+					__( 'Head Open Scripts', 'viget-wp' ),
+					function() {
+						$script = $this->get_scripts( 'head_open' );
+						?>
+						<textarea name="<?php echo esc_attr( self::OPTION_NAME ); ?>[head_open]" id="vigetwp_head_open_scripts" class="large-text code wp-code-mirror" rows="10"><?php echo esc_textarea( $script ); ?></textarea>
+						<?php
+					},
+					self::OPTION_NAME,
+					'vigetwp_head_scripts'
+				);
+
+				add_settings_field(
+					'vigetwp_head_close_scripts',
+					__( 'Head Close Scripts', 'viget-wp' ),
+					function() {
+						$script = $this->get_scripts( 'head_close' );
+						?>
+						<textarea name="<?php echo esc_attr( self::OPTION_NAME ); ?>[head_close]" id="vigetwp_head_close_scripts" class="large-text code wp-code-mirror" rows="10"><?php echo esc_textarea( $script ); ?></textarea>
+						<?php
+					},
+					self::OPTION_NAME,
+					'vigetwp_head_scripts'
+				);
+
+				add_settings_section(
+					'vigetwp_body_scripts',
+					__( 'Body Scripts', 'viget-wp' ),
+					'__return_empty_string',
+					self::OPTION_NAME
+				);
+
+				add_settings_field(
+					'vigetwp_body_open_scripts',
+					__( 'Body Open Scripts', 'viget-wp' ),
+					function() {
+						$script = $this->get_scripts( 'body_open' );
+						?>
+						<textarea name="<?php echo esc_attr( self::OPTION_NAME ); ?>[body_open]" id="vigetwp_body_open_scripts" class="large-text code wp-code-mirror" rows="10"><?php echo esc_textarea( $script ); ?></textarea>
+						<?php
+					},
+					self::OPTION_NAME,
+					'vigetwp_body_scripts'
+				);
+
+				add_settings_field(
+					'vigetwp_body_close_scripts',
+					__( 'Body Close Scripts', 'viget-wp' ),
+					function() {
+						$script = $this->get_scripts( 'body_close' );
+						?>
+						<textarea name="<?php echo esc_attr( self::OPTION_NAME ); ?>[body_close]" id="vigetwp_body_close_scripts" class="large-text code wp-code-mirror" rows="10"><?php echo esc_textarea( $script ); ?></textarea>
+						<?php
+					},
+					self::OPTION_NAME,
+					'vigetwp_body_scripts'
+				);
+			}
+		);
+	}
+
+	/**
+	 * Save Custom Scripts settings
+	 *
+	 * @return void
+	 */
+	private function save_settings(): void {
+		add_action(
+			'admin_init',
+			function() {
+				if ( ! isset( $_POST['_' . self::OPTION_NAME . '_nonce'] ) ) {
+					return;
+				}
+
+				if ( ! wp_verify_nonce( sanitize_key( $_POST['_' . self::OPTION_NAME . '_nonce'] ), self::PAGE_SLUG ) ) {
+					add_settings_error( self::OPTION_NAME, self::OPTION_NAME, __( 'Invalid nonce.', 'viget-wp' ) );
+					return;
+				}
+
+				$scripts = ! empty( $_POST[ self::OPTION_NAME ] ) ? $_POST[ self::OPTION_NAME ] : $this->scripts;
+				$allowed = [
+					'script' => [
+						'type' => [],
+						'src' => [],
+						'async' => [],
+						'defer' => [],
+					],
+					'noscript' => [],
+					'iframe' => [
+						'src' => [],
+						'width' => [],
+						'height' => [],
+						'style' => [],
+					],
+					'#text' => [], // Allow inline script content
+				];
+
+				foreach ( $scripts as $key => $script ) {
+					$script = wp_kses( wp_unslash( $script ), $allowed );
+					$scripts[ $key ] = html_entity_decode( $script, ENT_QUOTES | ENT_HTML5 );
+				}
+
+				update_option( self::OPTION_NAME, $scripts );
+
+				$this->scripts = $scripts;
+
+				add_settings_error( self::OPTION_NAME, self::OPTION_NAME, __( 'Settings saved.', 'viget-wp' ), 'updated' );
+			},
+			1
+		);
+	}
+
+	/**
+	 * Add custom scripts to the Tools menu
+	 *
+	 * @return void
+	 */
+	private function scripts_menu(): void {
+		add_action(
+			'admin_menu',
+			function() {
+				add_submenu_page(
+					'tools.php',
+					__( 'Custom Scripts', 'viget-wp' ),
+					'Custom Scripts',
+					'manage_options',
+					self::PAGE_SLUG,
+					[ $this, 'admin_page' ],
+					100
+				);
+			}
+		);
+	}
+
+	/**
+	 * Custom Scripts Admin page
+	 *
+	 * @return void
+	 */
+	public function admin_page(): void {
+		vigetwp()->load_view( 'admin/custom-scripts.php' );
+	}
+
+	/**
+	 * Enqueue admin assets for the Custom Scripts page
+	 *
+	 * @return void
+	 */
+	private function enqueue_admin_assets(): void {
+		add_action(
+			'admin_enqueue_scripts',
+			function ( string $hook ) {
+				if ( 'tools_page_' . self::PAGE_SLUG !== $hook ) {
+					return;
+				}
+
+				// Enqueue custom script
+				wp_enqueue_script(
+					self::PAGE_SLUG,
+					VIGETWP_PLUGIN_URL . 'src/assets/js/custom-scripts.js',
+					[ 'wp-codemirror' ],
+					VIGETWP_VERSION
+				);
+
+				// Enqueue custom style
+				wp_enqueue_style(
+					'wp-codemirror-tomorrow-night-eighties',
+					'https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.59.2/theme/tomorrow-night-eighties.min.css',
+					[ 'wp-codemirror' ],
+					'5.59.2'
+				);
+			}
+		);
+	}
+
+	/**
+	 * Insert custom scripts
+	 *
+	 * @return void
+	 */
+	private function insert_scripts(): void {
+		add_action(
+			'wp_head',
+			function() {
+				echo $this->get_scripts( 'head_open' );
+			},
+			1
+		);
+
+		add_action(
+			'wp_head',
+			function() {
+				echo $this->get_scripts( 'head_close' );
+			},
+			99999
+		);
+
+		add_action(
+			'wp_body_open',
+			function() {
+				echo $this->get_scripts( 'body_open' );
+			},
+			1
+		);
+
+		add_action(
+			'wp_footer',
+			function() {
+				echo $this->get_scripts( 'body_close' );
+			},
+			99999
+		);
+	}
+}

--- a/wp-content/mu-plugins/viget-wp/src/classes/Admin/CustomScripts.php
+++ b/wp-content/mu-plugins/viget-wp/src/classes/Admin/CustomScripts.php
@@ -275,8 +275,8 @@ class CustomScripts {
 
 				// Enqueue custom style
 				wp_enqueue_style(
-					'wp-codemirror-tomorrow-night-eighties',
-					'https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.59.2/theme/tomorrow-night-eighties.min.css',
+					'wp-codemirror-oceanic-next',
+					'https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.59.2/theme/oceanic-next.min.css',
 					[ 'wp-codemirror' ],
 					'5.59.2'
 				);

--- a/wp-content/mu-plugins/viget-wp/src/classes/Core.php
+++ b/wp-content/mu-plugins/viget-wp/src/classes/Core.php
@@ -8,20 +8,21 @@
 
 namespace VigetWP;
 
+use VigetWP\Admin\AdminBar;
 use VigetWP\Admin\Assets;
 use VigetWP\Admin\Blocks;
+use VigetWP\Admin\ColorScheme;
 use VigetWP\Admin\DashboardWidgets;
 use VigetWP\Admin\FileEditors;
+use VigetWP\Admin\Footer;
+use VigetWP\Admin\CustomScripts;
 use VigetWP\Admin\LoginScreen;
+use VigetWP\Admin\Menu;
 use VigetWP\Admin\TinyMCE;
 use VigetWP\Features\DisableComments;
 use VigetWP\Features\Gravatar;
 use VigetWP\Plugins\ACF\GravityForms;
 use VigetWP\Plugins\ACF\Toolbars;
-use VigetWP\Admin\AdminBar;
-use VigetWP\Admin\ColorScheme;
-use VigetWP\Admin\Footer;
-use VigetWP\Admin\Menu;
 
 /**
  * Core Class
@@ -152,6 +153,7 @@ class Core {
 		// Features
 		new DisableComments();
 		new Gravatar();
+		new CustomScripts();
 
 		// Admin
 		new Assets();

--- a/wp-content/mu-plugins/viget-wp/views/admin/custom-scripts.php
+++ b/wp-content/mu-plugins/viget-wp/views/admin/custom-scripts.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Custom Scripts Admin Page
+ *
+ * @package VigetWP
+ */
+
+use VigetWP\Admin\CustomScripts;
+
+?>
+<div class="wrap">
+	<h1><?php esc_html_e( 'Custom Scripts', 'viget-wp' ); ?></h1>
+
+	<?php settings_errors(); ?>
+
+	<form method="post" action="<?php echo admin_url( 'tools.php?page=' . CustomScripts::PAGE_SLUG ); ?>">
+		<?php
+		wp_nonce_field( 'vigetwp-custom-scripts', '_' . CustomScripts::OPTION_NAME . '_nonce' );
+		settings_fields( CustomScripts::OPTION_NAME );
+		do_settings_sections( CustomScripts::OPTION_NAME );
+		submit_button();
+		?>
+	</form>
+</div>

--- a/wp-content/mu-plugins/viget-wp/viget-wp.php
+++ b/wp-content/mu-plugins/viget-wp/viget-wp.php
@@ -3,13 +3,15 @@
  * Plugin Name: Viget WP
  * Plugin URI: https://github.com/vigetlabs/viget-wp
  * Description: WordPress Customization from Viget
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Viget
  * Author URI: https://www.viget.com/
  * Text Domain: viget-wp
  *
  * @package VigetWP
  */
+
+const VIGETWP_VERSION = '1.0.1';
 
 defined( 'VIGETWP_PLUGIN_FILE' ) || define( 'VIGETWP_PLUGIN_FILE', __FILE__ );
 defined( 'VIGETWP_PLUGIN_PATH' ) || define( 'VIGETWP_PLUGIN_PATH', plugin_dir_path( VIGETWP_PLUGIN_FILE ) );


### PR DESCRIPTION
# Summary

This PR adds a Custom Scripts page to the Tools menu, allowing admins to insert custom scripts into the `<head>` and `<body>` tags. This will render globally and do not have any way of rendering conditionally.

## Issues

* N/A

## Testing Instructions

1. Visit WP Admin
2. Go to Tools > Custom Scripts
3. Add custom scripts
4. Save changes
5. Review to ensure they are rendered properly on the front-end.

## Screenshots

<img width="1277" alt="Screenshot 2025-01-12 at 1 21 47 PM" src="https://github.com/user-attachments/assets/4642fd87-6b1d-4d2b-a3e2-aae8bccfd868" />

