### PR TITLE
[#123] Readme Updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-	"twiggy.framework": "ignore"
+	"twiggy.framework": "ignore",
+	"php.version": "8.2",
+	"intelephense.environment.phpVersion": "8.2"
 }

--- a/README.dist.md
+++ b/README.dist.md
@@ -23,6 +23,8 @@ This will install the WordPress files, composer packages, npm packages, and star
 
 You are all ready to start working on the site.
 
+Information on developing the theme, styling, and building blocks can be found in the theme [README](wp-content/themes/#UPDATETHIS/README.md).
+
 ### Build for production
 The deploy script should build the files for production, but if you want to test that out on your local server you can change the DDEV config.yaml `ENVIRONMENT` to `prod` and then `cd` into your custom theme folder and run `ddev npm run build`. This will build the JS and CSS files in the dist folder and out put a manifest file.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ git push -u origin main
 ```
 
 Be sure to update the origin with the correct remote repository URL (and remove the `<>` brackets).
+Information on developing the theme, styling, and building blocks can be found in the theme [README](wp-content/themes/wp-starter/README.md).
 
 # Development
 

--- a/wp-content/themes/wp-starter/README.md
+++ b/wp-content/themes/wp-starter/README.md
@@ -12,6 +12,11 @@ The `theme.json` holds a lot of the core WordPress theme settings. The `theme.js
 
 Several of the Tailwind variables are pulled in and Tailwind should be used as the primary way to style elements. If you need to, you can pull in more Tailwind variable for custom styling in `theme.json`.
 
+The files that create the `theme.json` can be used to set custom settings for blocks, global theme, or for custom templates. Here are a few references:
+- [Global Settings & Styles](https://developer.wordpress.org/block-editor/how-to-guides/themes/global-settings-and-styles/)
+- [Theme.json reference](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/)
+- [Global Styles & theme.json](https://fullsiteediting.com/lessons/global-styles/)
+
 ## Custom Blocks 🧱
 Blocks are build using ACF and core WordPress blocks. Styles for the blocks are in `src/styles/blocks`.
 
@@ -78,6 +83,11 @@ If you have need to apply the buttons style to the mark up you can add one of th
 | `.btn-outline-light` |
 | `.btn-text`          |
 
+#### Adding more Buttons Styles
+If you need to add more button styles you can [register](https://developer.wordpress.org/reference/functions/register_block_style/) a new block style on the `core/button`. Once you have the new button style registered you add the Tailwind style in `plugins-tailwind/buttons.js` and assign the class to the button in `/src/styles/core-blocks/buttons.css`. It is recommended that you create descriptive button styles and not generic styles like "primary" or "secondary". 
+
+#### Custom Button Icons
+The theme has a custom filter to add in custom icons for buttons. You can your custom SVG icons into `/src/images/icons/` and then pull in that SVG icon in `inc/icons.php`. In order for your SVG icon to update with the text you need to set `fill` or `stroke` (depending on your icon) to `currentColor`. 
 
 ### Navigation
 The navigation has been set up to be fully accessible and is built using [Alpine](https://alpinejs.dev/) and the styles are set in CSS. You can edit the JS in `/src/components/dropdown.js` and the CSS in `/src/styles/core-blocks/navigation.css` if you need to customize the navigation. 

--- a/wp-content/themes/wp-starter/README.md
+++ b/wp-content/themes/wp-starter/README.md
@@ -72,22 +72,55 @@ To adjust the spacing you can edit them in `tailwind.config.js` under `spacing >
 ### Buttons
 WordPress button styles are normally built in the `theme.json` but because there is a limitations on hover/focus for button variants all the buttons style are build in Tailwind.
 
-The Tailwind button plugin is in `plugins-tailwind/buttons.js` and has `default`, `outline`, and both light and dark version. In that file (`buttons.js`) is where you will update and style all of the buttons on the site. Those button styles are getting applied to the HTML in `/src/styles/core-blocks/buttons.css`. 
-If you have need to apply the buttons style to the mark up you can add one of these button classes.
+The button styles are getting applied to the HTML in `/src/styles/core-blocks/buttons.css`. 
+If you have need to apply the buttons style to the mark up you can add one of two button classes.
 
 | Button Classes       |
 |----------------------|
 | `.btn-default`       |
-| `.btn-default-light` |
 | `.btn-outline`       |
-| `.btn-outline-light` |
-| `.btn-text`          |
 
 #### Adding more Buttons Styles
-If you need to add more button styles you can [register](https://developer.wordpress.org/reference/functions/register_block_style/) a new block style on the `core/button`. Once you have the new button style registered you add the Tailwind style in `plugins-tailwind/buttons.js` and assign the class to the button in `/src/styles/core-blocks/buttons.css`. It is recommended that you create descriptive button styles and not generic styles like "primary" or "secondary". 
+If you need to add more button styles you can [register](https://developer.wordpress.org/reference/functions/register_block_style/) a new block style on the `core/button`. 
+
+```
+register_block_style(
+	'core/button',
+	[
+		'name'  => 'icon-only',
+		'label' => __( 'Icon Only', 'theme-slug' ),
+	]
+);
+```
+This will attach a class to the block in the pattern of `is-style-[name]`. Once you have the new button style registered you add the Tailwind style in `/src/styles/core-blocks/buttons.css`. It is recommended that you create descriptive button styles and not generic styles like "primary" or "secondary". 
 
 #### Custom Button Icons
 The theme has a custom filter to add in custom icons for buttons. You can your custom SVG icons into `/src/images/icons/` and then pull in that SVG icon in `inc/icons.php`. In order for your SVG icon to update with the text you need to set `fill` or `stroke` (depending on your icon) to `currentColor`. 
 
 ### Navigation
 The navigation has been set up to be fully accessible and is built using [Alpine](https://alpinejs.dev/) and the styles are set in CSS. You can edit the JS in `/src/components/dropdown.js` and the CSS in `/src/styles/core-blocks/navigation.css` if you need to customize the navigation. 
+
+
+## Troubleshooting
+
+### Editor Fonts
+
+The WP Editor requires WOFF2 fonts. TTF/OTF fonts will load on render for templates/pages, but will not display correctly in the Editor view unless they’re in WOFF2 format.
+
+### Editor Styles
+
+The Editor loads the generated Tailwind output, which means you need to run `ddev npm run build` to generate CSS the Editor will import.
+
+### Disconnected Template Parts
+
+If you edit a template part in the CMS (like the Header), WP will use the database version. To reset to the Code version:
+
+1. Open the template part in the Editor
+2. Click the part name in the top middle to bring up the Command Palette
+3. Type ‘Reset’ and select the command. This will remove DB modifications and reset to the code version.
+
+### Trying to find a value in `block.json`
+
+Not all the properties are completely documented, if you’re having trouble try:
+
+- The block schema at the main WP repo: https://github.com/WordPress/gutenberg/blob/trunk/schemas/json/block.json


### PR DESCRIPTION
# Summary
This updates the theme readme and the main repo readme.

- Adds links to the theme readme.
- Updates Buttons as we no longer are using the TW buttons JS.
- Adds some reference links. 
- Adds more info on creating Buttons Styles pulled from our [developer guide](https://www.notion.so/viget/WP-Site-Starter-Developer-Guide-12a6c4ac83fe8041ae82d3d4b4f38cf3?pvs=4).
- Adds a troubleshooting section which is taken from our [developer guide](https://www.notion.so/viget/WP-Site-Starter-Developer-Guide-12a6c4ac83fe8041ae82d3d4b4f38cf3?pvs=4).

## Issues

* #123