### PR TITLE
[#207] Firefox Fonts Bug Fix

### DIFF
--- a/wp-content/themes/wp-starter/package-lock.json
+++ b/wp-content/themes/wp-starter/package-lock.json
@@ -387,7 +387,7 @@
       "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
       "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
       "cpu": [
-        "ppc64"
+        "s390x"
       ],
       "dev": true,
       "license": "MIT",
@@ -438,7 +438,7 @@
       "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
       "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
       "cpu": [
-        "x64"
+        "wasm32"
       ],
       "dev": true,
       "license": "MIT",

--- a/wp-content/themes/wp-starter/postcss.config.cjs
+++ b/wp-content/themes/wp-starter/postcss.config.cjs
@@ -1,7 +1,17 @@
+const postcssImportExtGlob = require('postcss-import-ext-glob');
+const tailwindPostcss = require('@tailwindcss/postcss');
+const cssnano = require('cssnano');
+const { postcssPlugin: ffFluidFonts } = require('./src/plugins/fluid-font-calculations.cjs');
+
+/**
+ * Use an array here so postcss-load-config does not treat keys as npm package
+ * names (e.g. `postcss-ff-fluid-fonts` would try require('postcss-ff-fluid-fonts')).
+ */
 module.exports = {
-	plugins: {
-		'postcss-import-ext-glob': {},
-		'@tailwindcss/postcss': {},
-		...(process.env.NODE_ENV === 'prod' ? { cssnano: {} } : {})
-  },
-}
+	plugins: [
+		postcssImportExtGlob(),
+		tailwindPostcss(),
+		ffFluidFonts(),
+		...(process.env.NODE_ENV === 'prod' ? [cssnano()] : []),
+	],
+};

--- a/wp-content/themes/wp-starter/src/plugins/fluid-font-calculations.cjs
+++ b/wp-content/themes/wp-starter/src/plugins/fluid-font-calculations.cjs
@@ -1,0 +1,146 @@
+/**
+ * Firefox-safe fluid font clamps: replaces length/length calc (invalid in Firefox)
+ * with clamp(min, calc(interceptPx + slopeVw * 1vw), max).
+ *
+ * Reads breakpoint max from tailwind @theme (--breakpoint-container) and ranges
+ * from font-sizes.css. See plan: bpMax must match @theme; --cfg-fluid-bp-max in
+ * CSS may still use WP vars for documentation.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const THEME_ROOT = path.join(__dirname, '..', '..');
+
+const FLUID_TOKENS = ['sm', 'base', 'md', 'lg', 'xl', '2xl'];
+
+/** @param {string} themeRoot */
+function readFontSizes(themeRoot) {
+	const p = path.join(themeRoot, 'src/styles/tailwind/inc/font-sizes.css');
+	const src = fs.readFileSync(p, 'utf8');
+	const bpMinM = src.match(/--cfg-fluid-bp-min:\s*(\d+)/);
+	if (!bpMinM) {
+		throw new Error('[fluid-font-calculations] Could not parse --cfg-fluid-bp-min from font-sizes.css');
+	}
+	const bpMin = parseInt(bpMinM[1], 10);
+	const ranges = {};
+	for (const token of FLUID_TOKENS) {
+		const minRe = new RegExp(`--fs-${token}-min:\\s*([^;]+);`, 'm');
+		const maxRe = new RegExp(`--fs-${token}-max:\\s*([^;]+);`, 'm');
+		const minM = src.match(minRe);
+		const maxM = src.match(maxRe);
+		if (!minM || !maxM) {
+			throw new Error(`[fluid-font-calculations] Missing --fs-${token}-min/max in font-sizes.css`);
+		}
+		ranges[token] = { min: minM[1].trim(), max: maxM[1].trim() };
+	}
+	return { bpMin, ranges };
+}
+
+/** @param {string} themeRoot */
+function readBreakpointContainerPx(themeRoot) {
+	const p = path.join(themeRoot, 'src/styles/tailwind/tailwind.css');
+	const src = fs.readFileSync(p, 'utf8');
+	const m = src.match(/--breakpoint-container:\s*([\d.]+)px/);
+	if (!m) {
+		throw new Error('[fluid-font-calculations] Could not parse --breakpoint-container from tailwind.css');
+	}
+	return parseFloat(m[1]);
+}
+
+/**
+ * @param {string} length rem or px string
+ * @param {number} rootPx
+ */
+function lengthToPx(length, rootPx) {
+	const s = length.trim();
+	const rem = s.match(/^([\d.]+)rem$/i);
+	if (rem) return parseFloat(rem[1]) * rootPx;
+	const px = s.match(/^([\d.]+)px$/i);
+	if (px) return parseFloat(px[1]);
+	throw new Error(`[fluid-font-calculations] Unsupported length (use rem or px): ${length}`);
+}
+
+function round(n, digits = 4) {
+	const f = 10 ** digits;
+	return Math.round(n * f) / f;
+}
+
+/**
+ * @param {{ bpMin: number, bpMax: number, rootPx?: number, themeRoot?: string }} opts
+ * @returns {Map<string, string>} prop -> full clamp() value
+ */
+function buildFluidTextReplacements(opts) {
+	const { bpMin, bpMax, rootPx = 16, themeRoot = THEME_ROOT } = opts;
+	if (bpMax <= bpMin) {
+		throw new Error(`[fluid-font-calculations] bpMax (${bpMax}) must be > bpMin (${bpMin})`);
+	}
+	const { ranges } = readFontSizes(themeRoot);
+	const rangePx = bpMax - bpMin;
+	const map = new Map();
+
+	for (const token of FLUID_TOKENS) {
+		const { min, max } = ranges[token];
+		const minPx = lengthToPx(min, rootPx);
+		const maxPx = lengthToPx(max, rootPx);
+		const deltaF = maxPx - minPx;
+		const slope = deltaF / rangePx;
+		const slopeVw = round(slope * 100, 4);
+		const intercept = round(minPx - slope * bpMin, 4);
+		const mid =
+			deltaF === 0
+				? min
+				: `calc(${intercept}px + ${slopeVw}vw)`;
+		const prop = `--fluid-text-${token}`;
+		const clampVal = `clamp(var(--fs-${token}-min), ${mid}, var(--fs-${token}-max))`;
+		map.set(prop, clampVal);
+	}
+	return map;
+}
+
+/** @param {string} varRef e.g. var(--fluid-text-lg) */
+function tokenFromFluidVar(varRef) {
+	const m = String(varRef).trim().match(/^var\(\s*--fluid-text-(\w+)\s*\)$/i);
+	return m ? m[1] : null;
+}
+
+/**
+ * Map of CSS custom property -> full clamp string (for PostCSS + theme.json).
+ * @param {string} [themeRoot]
+ */
+function getFluidTextDeclMap(themeRoot = THEME_ROOT) {
+	const bpMin = readFontSizes(themeRoot).bpMin;
+	const bpMax = readBreakpointContainerPx(themeRoot);
+	return buildFluidTextReplacements({ bpMin, bpMax, themeRoot });
+}
+
+function postcssPlugin() {
+	return {
+		postcssPlugin: 'postcss-ff-fluid-fonts',
+		Once(root) {
+			const declMap = getFluidTextDeclMap();
+			root.walkDecls((decl) => {
+				if (decl.prop === '--fluid-t') {
+					decl.remove();
+					return;
+				}
+				const next = declMap.get(decl.prop);
+				if (next) {
+					decl.value = next;
+				}
+			});
+		},
+	};
+}
+postcssPlugin.postcss = true;
+
+module.exports = {
+	THEME_ROOT,
+	FLUID_TOKENS,
+	readFontSizes,
+	readBreakpointContainerPx,
+	buildFluidTextReplacements,
+	getFluidTextDeclMap,
+	tokenFromFluidVar,
+	postcssPlugin,
+};

--- a/wp-content/themes/wp-starter/src/plugins/vite-scoped-editor-styles.js
+++ b/wp-content/themes/wp-starter/src/plugins/vite-scoped-editor-styles.js
@@ -22,7 +22,7 @@
  */
 
 import path from 'path';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'node:module';
 import postcss from 'postcss';
@@ -30,6 +30,9 @@ import postcss from 'postcss';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const { postcssPlugin: postcssFfFluidFonts } = require('./fluid-font-calculations.cjs');
+
+/** Absolute path to fluid math + PostCSS plugin (used for explicit watch). */
+const FLUID_FONT_CALCULATIONS = path.join(__dirname, 'fluid-font-calculations.cjs');
 
 const VIRTUAL_MODULE_ID = 'virtual:editor-scoped-styles';
 const RESOLVED_ID = '\0' + VIRTUAL_MODULE_ID;
@@ -290,15 +293,34 @@ export default function viteEditorStyles(options = {}) {
 
 			const { scopedCss, unscopedCss, deps } = await cssVariantsPromise;
 
+			// Only watch files that exist. Tailwind's incremental compiler can retain
+			// stale `dependency` messages (e.g. after moving fluid-font-calculations.cjs);
+			// addWatchFile on a missing path makes Vite treat it as an import and fail.
 			for (const dep of deps) {
-				this.addWatchFile(dep);
+				if (existsSync(dep)) {
+					this.addWatchFile(dep);
+				}
 			}
+
+			this.addWatchFile(FLUID_FONT_CALCULATIONS);
 
 			return buildModule(scopedCss, unscopedCss);
 		},
 
 		handleHotUpdate({ file, modules, server }) {
-			if (!file.endsWith('.css')) return;
+			const isCss = file.endsWith('.css');
+			const isPostcssConfig = file.endsWith('postcss.config.cjs');
+			const isFluidCalc = file.endsWith('fluid-font-calculations.cjs');
+			const isThisPlugin = file.endsWith('vite-scoped-editor-styles.js');
+
+			if (!isCss && !isPostcssConfig && !isFluidCalc && !isThisPlugin) {
+				return;
+			}
+
+			// Drop Tailwind's processor so the next build does not reuse stale dependency paths.
+			if (isPostcssConfig || isFluidCalc || isThisPlugin) {
+				cssProcessor = null;
+			}
 
 			triggerBuild();
 

--- a/wp-content/themes/wp-starter/src/plugins/vite-scoped-editor-styles.js
+++ b/wp-content/themes/wp-starter/src/plugins/vite-scoped-editor-styles.js
@@ -24,9 +24,12 @@
 import path from 'path';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
+import { createRequire } from 'node:module';
 import postcss from 'postcss';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const { postcssPlugin: postcssFfFluidFonts } = require('./fluid-font-calculations.cjs');
 
 const VIRTUAL_MODULE_ID = 'virtual:editor-scoped-styles';
 const RESOLVED_ID = '\0' + VIRTUAL_MODULE_ID;
@@ -210,7 +213,11 @@ export default function viteEditorStyles(options = {}) {
 			import('@tailwindcss/postcss'),
 		]);
 
-		cssProcessor = postcss([postcssImportExtGlob(), tailwindPostcss()]);
+		cssProcessor = postcss([
+			postcssImportExtGlob(),
+			tailwindPostcss(),
+			postcssFfFluidFonts(),
+		]);
 		return cssProcessor;
 	}
 

--- a/wp-content/themes/wp-starter/src/styles/tailwind/inc/font-calculations.css
+++ b/wp-content/themes/wp-starter/src/styles/tailwind/inc/font-calculations.css
@@ -1,3 +1,4 @@
+/* PostCSS (postcss-ff-fluid-fonts) removes --fluid-t and rewrites --fluid-text-* for Firefox-safe clamp(..., calc(px + vw), ...). */
 :root {
 	/* Viewport breakpoints (pulled from font-sizes config) */
 	--fluid-bp-min: var(--cfg-fluid-bp-min);

--- a/wp-content/themes/wp-starter/src/styles/tailwind/inc/font-families.css
+++ b/wp-content/themes/wp-starter/src/styles/tailwind/inc/font-families.css
@@ -1,3 +1,10 @@
+/**
+There shouldn't be a need to change these here unless adding a new font:
+--cfg-font-alt: var(--wp--preset--font-family--alt);
+
+Manage fonts from theme-json/settings/typography.js file.
+
+*/
 :root {
 	--cfg-font-body: var(--wp--preset--font-family--body);
 	--cfg-font-heading: var(--wp--preset--font-family--heading);

--- a/wp-content/themes/wp-starter/src/theme-json/generate.js
+++ b/wp-content/themes/wp-starter/src/theme-json/generate.js
@@ -1,18 +1,33 @@
 import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import settings from './settings/_index.js';
 import styles from './styles/_index.js';
 import templateParts from './template-parts/_index.js';
 
-const CONTENT_PATH = 'src/theme-json';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Directory containing this file (`src/theme-json`). */
+const THEME_JSON_DIR = __dirname;
+
+/** Fluid typography sources: changing breakpoints or font ranges should refresh theme.json presets. */
+const FLUID_CSS_WATCH_PATHS = [
+	path.join(__dirname, '../styles/tailwind/tailwind.css'),
+	path.join(__dirname, '../styles/tailwind/inc/font-sizes.css'),
+];
 
 const generateThemeJSON = {
 	name: 'generate-theme-json',
 	configureServer(server) {
-		// Watch the `CONTENT_PATH` directory for changes
-		fs.watch(CONTENT_PATH, () => {
-			// Regenerate the file when a change is detected
+		const rebuild = () => {
 			buildJSON();
-		});
+		};
+
+		fs.watch(THEME_JSON_DIR, rebuild);
+
+		for (const watchPath of FLUID_CSS_WATCH_PATHS) {
+			fs.watch(watchPath, rebuild);
+		}
 	},
 };
 

--- a/wp-content/themes/wp-starter/src/theme-json/generate.js
+++ b/wp-content/themes/wp-starter/src/theme-json/generate.js
@@ -22,7 +22,7 @@ function buildJSON() {
 		styles: styles,
 		templateParts: templateParts,
 		version: 3,
-		$schema: 'https://schemas.wp.org/wp/6.8/theme.json',
+		$schema: 'https://schemas.wp.org/wp/6.9/theme.json',
 	};
 
 	fs.writeFileSync('theme.json', JSON.stringify(data, null, 2));

--- a/wp-content/themes/wp-starter/src/theme-json/helpers/fonts.js
+++ b/wp-content/themes/wp-starter/src/theme-json/helpers/fonts.js
@@ -5,7 +5,11 @@
 
 import fs from 'fs';
 import path from 'path';
+import { createRequire } from 'node:module';
 import { toTitleCase } from './strings.js';
+
+const require = createRequire(import.meta.url);
+const { getFluidTextDeclMap, tokenFromFluidVar, THEME_ROOT } = require('../../plugins/fluid-font-calculations.cjs');
 
 /** Supported filters for block-specific font sizes (--text-{filter}-*). */
 const SUPPORTED_FILTERS = ['headline', 'ui'];
@@ -61,8 +65,9 @@ function getFontSizes( filter = '' ) {
 		return [];
 	}
 
-	const cssPath = path.join(process.cwd(), 'src/styles/tailwind/typography.css');
+	const cssPath = path.join(THEME_ROOT, 'src/styles/tailwind/typography.css');
 	const cssContent = fs.readFileSync(cssPath, 'utf8');
+	const fluidClampByProp = getFluidTextDeclMap(THEME_ROOT);
 
 	const matches = [];
 	const regex = filter
@@ -77,10 +82,16 @@ function getFontSizes( filter = '' ) {
 	return matches
 		.filter( ( { token } ) => ( filter ? true : token !== 'zero' ) )
 		.map( ( { token, sizeValue } ) => {
+			const fluidToken = tokenFromFluidVar(sizeValue);
+			const size =
+				fluidToken && fluidClampByProp.has(`--fluid-text-${fluidToken}`)
+					? fluidClampByProp.get(`--fluid-text-${fluidToken}`)
+					: sizeValue;
+
 			return {
 				fluid: false,
 				name: fontNames[token] || toTitleCase( token ),
-				size: sizeValue,
+				size,
 				slug: fontSlugs[token] || token.toLowerCase(),
 			};
 		} );

--- a/wp-content/themes/wp-starter/src/theme-json/helpers/fonts.js
+++ b/wp-content/themes/wp-starter/src/theme-json/helpers/fonts.js
@@ -1,55 +1,89 @@
+/**
+ * This file is used to extract the font sizes from:
+ * - src/styles/tailwind/typography.css
+ */
+
 import fs from 'fs';
 import path from 'path';
 import { toTitleCase } from './strings.js';
 
+/** Supported filters for block-specific font sizes (--text-{filter}-*). */
+const SUPPORTED_FILTERS = ['headline', 'ui'];
+
+const fontNames = {
+	zero: 'Zero',
+	tiny: 'Tiny',
+	'2xs': '2X Small',
+	xxs: '2X Small',
+	xs: 'Extra Small',
+	sm: 'Small',
+	base: 'Base',
+	md: 'Medium',
+	lg: 'Large',
+	xl: 'Extra Large',
+	xxl: '2X Large',
+	'2xl': '2X Large',
+	xxxl: '3X Large',
+	'3xl': '3X Large',
+};
+
+const fontSlugs = {
+	zero: 'zero',
+	tiny: 'tiny',
+	'2xs': 'xx-small',
+	xxs: 'xx-small',
+	xs: 'x-small',
+	sm: 'small',
+	base: 'base',
+	md: 'medium',
+	lg: 'large',
+	xl: 'x-large',
+	xxl: '2x-large',
+	'2xl': '2x-large',
+	xxxl: '3x-large',
+	'3xl': '3x-large',
+};
+
+/** Body-scale token names (no filter); derived from fontSlugs keys. */
+const BODY_TOKEN_KEYS = Object.keys(fontSlugs);
+
 /**
- * Get the font sizes from the styles/tailwind/typography.css file.
- * @returns {Object} The font sizes.
+ * Get font sizes from the theme's typography CSS for theme.json.
+ * Default (no filter): body scale (--text-* for any fontSlugs token), excluding zero.
+ * With filter ("headline" or "ui"): only --text-{filter}-* tokens.
+ * Returns size as the variable value from typography.css (e.g. var(--cfg-text-xs) or var(--fluid-text-m)).
+ *
+ * @param {string} filter - Optional filter: "headline" or "ui". Other values return [].
+ * @returns {Array<{fluid: boolean, name: string, size: string, slug: string}>} The font sizes.
  */
-function getFontSizes() {
+function getFontSizes( filter = '' ) {
+	if ( filter && !SUPPORTED_FILTERS.includes(filter) ) {
+		return [];
+	}
+
 	const cssPath = path.join(process.cwd(), 'src/styles/tailwind/typography.css');
 	const cssContent = fs.readFileSync(cssPath, 'utf8');
-	const fontSizes = cssContent.match(/--text-\w+:\s*([^;]+);/g);
 
-	const fontNames = {
-		tiny: 'Tiny',
-		'2xs': '2X Small',
-		xxs: '2X Small',
-		xs: 'Extra Small',
-		sm: 'Small',
-		md: 'Medium',
-		lg: 'Large',
-		xl: 'Extra Large',
-		xxl: '2X Large',
-		'2xl': '2X Large',
-	};
+	const matches = [];
+	const regex = filter
+		? new RegExp(`--text-${filter}-(\\w+):\\s*([^;]+);`, 'g')
+		: new RegExp(`--text-(${BODY_TOKEN_KEYS.join('|')}):\\s*([^;]+);`, 'g');
 
-	const fontSlugs = {
-		tiny: 'tiny',
-		'2xs': 'xx-small',
-		xxs: 'xx-small',
-		xs: 'x-small',
-		sm: 'small',
-		md: 'medium',
-		lg: 'large',
-		xl: 'x-large',
-		xxl: '2x-large',
-		'2xl': '2x-large',
-	};
+	let match;
+	while ( ( match = regex.exec( cssContent ) ) !== null ) {
+		matches.push( { token: match[1], sizeValue: match[2].trim() } );
+	}
 
-	return fontSizes.flatMap((fontSize) => {
-		const match = fontSize.match(/--text-(\w+):\s*([^;]+);/);
-		const [, size, value] = match;
-
-		if (size === 'zero') return [];
-
-		return [{
-			fluid: false,
-			name: fontNames[size] || toTitleCase(size),
-			size: value.trim(),
-			slug: fontSlugs[size] || size.toLowerCase(),
-		}];
-	});
+	return matches
+		.filter( ( { token } ) => ( filter ? true : token !== 'zero' ) )
+		.map( ( { token, sizeValue } ) => {
+			return {
+				fluid: false,
+				name: fontNames[token] || toTitleCase( token ),
+				size: sizeValue,
+				slug: fontSlugs[token] || token.toLowerCase(),
+			};
+		} );
 }
 
 export { getFontSizes };

--- a/wp-content/themes/wp-starter/src/theme-json/styles/css.js
+++ b/wp-content/themes/wp-starter/src/theme-json/styles/css.js
@@ -3,13 +3,26 @@ import color from '../settings/color.js';
 let css =
 	':where(.wp-site-blocks *:focus-visible){outline-width:2px;outline-style:solid}';
 
+// Exclude elements inside light backgrounds (so they keep dark text) and inside map/embed containers
+const lightBgExclusions = color.palette
+	.filter((item) => !item.slug.startsWith('dark-'))
+	.map(
+		(item) =>
+			`:not(.has-${item.slug}-background-color):not(.has-${item.slug}-background-color *)`,
+	)
+	.join('');
+const mapAndLightBlockExclusions =
+	':not(.sf-map-canvas):not(.sf-map-canvas *)' +
+	':not(:has(div > .gm-style))' +
+	':not(.acf-block-salesforce-map-embed):not(.acf-block-salesforce-map-embed *)';
+
 // Loop through color.palette and add selectors for any colors that start with 'dark-'
 for (const item of color.palette) {
 	if (item.slug.startsWith('dark-')) {
 		css += `.has-${item.slug}-background-color:not(.has-text-color),
 		.has-${item.slug}-background-color:not(.has-text-color) .wp-block-button__link:not(.has-text-color),
 		.has-${item.slug}-background-color:not(.has-text-color) .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
-		.has-${item.slug}-background-color:not(.has-text-color) *:not(.has-text-color,.has-inline-color):not(.wp-block-button__link-icon):not(svg, polygon){color:var(--wp--preset--color--white);}`;
+		.has-${item.slug}-background-color:not(.has-text-color) *:not(.has-text-color,.has-inline-color):not(.wp-block-button__link-icon):not(svg, path, polygon):not(.components-button):not(.components-placeholder):not(.components-placeholder__label):not(.components-placeholder__instructions)${mapAndLightBlockExclusions}${lightBgExclusions}{color:var(--wp--preset--color--white);}`;
 	}
 }
 

--- a/wp-content/themes/wp-starter/theme.json
+++ b/wp-content/themes/wp-starter/theme.json
@@ -705,7 +705,7 @@
       "fontWeight": "400",
       "lineHeight": "1.55"
     },
-    "css": ":where(.wp-site-blocks *:focus-visible){outline-width:2px;outline-style:solid}.has-dark-black-background-color:not(.has-text-color),\n\t\t.has-dark-black-background-color:not(.has-text-color) .wp-block-button__link:not(.has-text-color),\n\t\t.has-dark-black-background-color:not(.has-text-color) .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),\n\t\t.has-dark-black-background-color:not(.has-text-color) *:not(.has-text-color,.has-inline-color):not(.wp-block-button__link-icon):not(svg, polygon){color:var(--wp--preset--color--white);}"
+    "css": ":where(.wp-site-blocks *:focus-visible){outline-width:2px;outline-style:solid}.has-dark-black-background-color:not(.has-text-color),\n\t\t.has-dark-black-background-color:not(.has-text-color) .wp-block-button__link:not(.has-text-color),\n\t\t.has-dark-black-background-color:not(.has-text-color) .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),\n\t\t.has-dark-black-background-color:not(.has-text-color) *:not(.has-text-color,.has-inline-color):not(.wp-block-button__link-icon):not(svg, path, polygon):not(.components-button):not(.components-placeholder):not(.components-placeholder__label):not(.components-placeholder__instructions):not(.sf-map-canvas):not(.sf-map-canvas *):not(:has(div > .gm-style)):not(.acf-block-salesforce-map-embed):not(.acf-block-salesforce-map-embed *):not(.has-white-background-color):not(.has-white-background-color *){color:var(--wp--preset--color--white);}"
   },
   "templateParts": [
     {

--- a/wp-content/themes/wp-starter/theme.json
+++ b/wp-content/themes/wp-starter/theme.json
@@ -134,37 +134,37 @@
         {
           "fluid": false,
           "name": "Small",
-          "size": "var(--fluid-text-sm)",
+          "size": "clamp(var(--fs-sm-min), calc(11.0909px + 0.2424vw), var(--fs-sm-max))",
           "slug": "small"
         },
         {
           "fluid": false,
           "name": "Base",
-          "size": "var(--fluid-text-base)",
+          "size": "clamp(var(--fs-base-min), 1rem, var(--fs-base-max))",
           "slug": "base"
         },
         {
           "fluid": false,
           "name": "Medium",
-          "size": "var(--fluid-text-md)",
+          "size": "clamp(var(--fs-md-min), calc(15.2727px + 0.7273vw), var(--fs-md-max))",
           "slug": "medium"
         },
         {
           "fluid": false,
           "name": "Large",
-          "size": "var(--fluid-text-lg)",
+          "size": "clamp(var(--fs-lg-min), calc(20.3636px + 0.9697vw), var(--fs-lg-max))",
           "slug": "large"
         },
         {
           "fluid": false,
           "name": "Extra Large",
-          "size": "var(--fluid-text-xl)",
+          "size": "clamp(var(--fs-xl-min), calc(24.7273px + 1.9394vw), var(--fs-xl-max))",
           "slug": "x-large"
         },
         {
           "fluid": false,
           "name": "2X Large",
-          "size": "var(--fluid-text-2xl)",
+          "size": "clamp(var(--fs-2xl-min), calc(40.7273px + 1.9394vw), var(--fs-2xl-max))",
           "slug": "2x-large"
         }
       ]
@@ -720,5 +720,5 @@
     }
   ],
   "version": 3,
-  "$schema": "https://schemas.wp.org/wp/6.8/theme.json"
+  "$schema": "https://schemas.wp.org/wp/6.9/theme.json"
 }


### PR DESCRIPTION
# Summary

This PR implements a script to fix `clamp()` related bugs that affect font-sizing in Firefox.

It also adds support for Google Maps to prevent dark background colors from affecting Labels and such in Google Maps.

## Issues

* #207 
* #209 

## Testing Instructions

1. Check fonts in Chrome and Firefox.
