### PR TITLE
[#211] Allow colors in Tailwind but not Theme

### DIFF
--- a/wp-content/themes/wp-starter/src/styles/tailwind/colors.css
+++ b/wp-content/themes/wp-starter/src/styles/tailwind/colors.css
@@ -1,7 +1,7 @@
-@theme {
-	/* Colors */
-	--color-transparent: transparent;
-	--color-current: currentColor;
-	--color-white: #ffffff;
-	--color-black: #000000;
-}
+/**
+ * Colors are defined in the following files:
+ * - inc/colors-palette.css: Theme/Editor-specific colors.
+ * - inc/colors-utilities.css: Tailwind-only colors.
+ */
+@import './inc/colors-palette.css';
+@import './inc/colors-utilities.css';

--- a/wp-content/themes/wp-starter/src/styles/tailwind/inc/colors-palette.css
+++ b/wp-content/themes/wp-starter/src/styles/tailwind/inc/colors-palette.css
@@ -1,0 +1,13 @@
+/*
+ * Block editor + theme.json palette
+ * -------------------------------
+ * Colors and gradients defined here are read by src/theme-json/helpers/colors.js
+ * and become WordPress color / gradient presets (block picker, theme.json).
+ *
+ * For Tailwind-only tokens that must not appear in the editor, use `colors-utilities.css`.
+ */
+@theme {
+	/* Theme Colors */
+	--color-white: #ffffff;
+	--color-black: #000000;
+}

--- a/wp-content/themes/wp-starter/src/styles/tailwind/inc/colors-utilities.css
+++ b/wp-content/themes/wp-starter/src/styles/tailwind/inc/colors-utilities.css
@@ -1,0 +1,10 @@
+/*
+ * Tailwind-only theme tokens
+ * --------------------------
+ * This file is not read by theme-json/helpers/colors.js.
+ */
+@theme {
+	--color-transparent: transparent;
+	--color-current: currentColor;
+ 	--color-accent: #00A3EE;
+}

--- a/wp-content/themes/wp-starter/src/theme-json/helpers/colors.js
+++ b/wp-content/themes/wp-starter/src/theme-json/helpers/colors.js
@@ -56,13 +56,20 @@ function isDark(color) {
 	return luminance < 0.179;
 }
 
+/** File whose @theme block defines colors synced to theme.json / the block editor. */
+const EDITOR_PALETTE_CSS = path.join(
+	process.cwd(),
+	'src/styles/tailwind/inc/colors-palette.css',
+);
+
 /**
- * Parse the CSS file to extract color variables from the @theme directive.
+ * Parse the palette CSS file to extract color variables from the @theme directive.
+ * Tailwind-only colors live in colors-utilities.css and are intentionally not parsed here.
  *
  * @returns {object} The color palette object
  */
 function parseColorsFromCSS() {
-	const cssPath = path.join(process.cwd(), 'src/styles/tailwind/colors.css');
+	const cssPath = EDITOR_PALETTE_CSS;
 
 	try {
 		const cssContent = fs.readFileSync(cssPath, 'utf8');
@@ -101,12 +108,12 @@ function parseColorsFromCSS() {
 }
 
 /**
- * Parse the CSS file to extract gradient variables from the @theme directive.
+ * Parse the palette CSS file to extract gradient variables from the @theme directive.
  *
  * @returns {object} The gradient palette object
  */
 function parseGradientsFromCSS() {
-	const cssPath = path.join(process.cwd(), 'src/styles/tailwind/colors.css');
+	const cssPath = EDITOR_PALETTE_CSS;
 
 	try {
 		const cssContent = fs.readFileSync(cssPath, 'utf8');

--- a/wp-content/themes/wp-starter/src/theme-json/settings/color.js
+++ b/wp-content/themes/wp-starter/src/theme-json/settings/color.js
@@ -1,5 +1,9 @@
 import { getPalette, getGradients } from '../helpers/colors.js';
 
+/**
+ * Palette and gradients come from `src/styles/tailwind/inc/colors-palette.css` only.
+ * Add Tailwind-only tokens in `colors-utilities.css` so they stay out of the block editor.
+ */
 export default {
 	defaultDuotone: false,
 	defaultPalette: false,


### PR DESCRIPTION
# Summary

This PR separates colors into 2 different files so some colors can be added to Tailwind without adding them to the Theme Color picker (theme.json).

## Issues

* #211 

## Testing Instructions

1. Notice the Accent Color (`#00A3EE`) is not available in the color picker.
