### PR TITLE
[N/A] Replace local URLs after templates are updated via CBT Plugin

### DIFF
--- a/wp-content/mu-plugins/viget-wp/src/classes/Core.php
+++ b/wp-content/mu-plugins/viget-wp/src/classes/Core.php
@@ -21,6 +21,7 @@ use VigetWP\Admin\Menu;
 use VigetWP\Admin\TinyMCE;
 use VigetWP\Features\DisableComments;
 use VigetWP\Features\Gravatar;
+use VigetWP\Plugins\CreateBlockTheme;
 use VigetWP\Plugins\ACF\GravityForms;
 use VigetWP\Plugins\ACF\Toolbars;
 
@@ -166,7 +167,8 @@ class Core {
 		new DashboardWidgets();
 		new FileEditors();
 
-		## Plugins
+		// Plugins
+		new CreateBlockTheme();
 
 		// ACF
 		new Toolbars();

--- a/wp-content/mu-plugins/viget-wp/src/classes/Plugins/CreateBlockTheme.php
+++ b/wp-content/mu-plugins/viget-wp/src/classes/Plugins/CreateBlockTheme.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Create Block Theme Class
+ *
+ * @package VigetWP
+ */
+
+namespace VigetWP\Plugins;
+
+/**
+ * Create Block Theme Class
+ */
+class CreateBlockTheme {
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_filter(
+			'rest_post_dispatch',
+			function ( $result, $server, $request ) {
+				$route = $request->get_route();
+
+				if ( '/create-block-theme/v1/save' !== $route ) {
+					return $result;
+				}
+
+				$this->clean_theme_files();
+
+				return $result;
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Clean theme files
+	 */
+	private function clean_theme_files(): void {
+		$templates = glob( get_stylesheet_directory() . '/templates/*.{php,html}', GLOB_BRACE );
+
+		// Replace the home_url() with relative URLs in the template files.
+		foreach ( $templates as $template ) {
+			$content  = file_get_contents( $template );
+			$home_url = trailingslashit( home_url() );
+			$content  = str_replace( $home_url, '/', $content );
+			file_put_contents( $template, $content );
+		}
+	}
+}


### PR DESCRIPTION
# Summary

This PR fixes an issue where CBT writes template files by removing the local DDEV URL, making URLs in the template files relative.

## Issues

* Somewhat related to issue #189

## Testing Instructions

1. Save a template using Create Block Theme
2. Confirm there are instances of the DDEV URL hard-coded into the template files.
