### PR TITLE
[N/A] Update Timber to latest

### DIFF
--- a/wp-content/themes/wp-starter/composer.json
+++ b/wp-content/themes/wp-starter/composer.json
@@ -26,7 +26,7 @@
     "php": ">=8.2.0",
     "ext-json": "*",
     "idleberg/wordpress-vite-assets": "^1.2",
-    "timber/timber": "^2.3",
+    "timber/timber": "^2.4",
     "viget/viget-blocks-toolkit": "^1.1",
     "wpackagist-plugin/accessibility-checker": "^1.39",
     "wpackagist-plugin/safe-svg": "^2.4",

--- a/wp-content/themes/wp-starter/composer.lock
+++ b/wp-content/themes/wp-starter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1575f5c3b983d0cd1ec825b661a4e94",
+    "content-hash": "9a2d6017734105593317daaa0258c2d5",
     "packages": [
         {
             "name": "composer/installers",
@@ -825,38 +825,54 @@
         },
         {
             "name": "timber/timber",
-            "version": "v2.3.3",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/timber/timber.git",
-                "reference": "7a87ac27c0b9deedffe419388b63a0c95d8798ca"
+                "reference": "44c7171d154ee697bab416a31852b9340845cc7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/timber/timber/zipball/7a87ac27c0b9deedffe419388b63a0c95d8798ca",
-                "reference": "7a87ac27c0b9deedffe419388b63a0c95d8798ca",
+                "url": "https://api.github.com/repos/timber/timber/zipball/44c7171d154ee697bab416a31852b9340845cc7f",
+                "reference": "44c7171d154ee697bab416a31852b9340845cc7f",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1",
+                "php": "^8.2",
                 "twig/twig": "^3.19"
             },
             "require-dev": {
+                "composer/installers": "^2",
                 "ergebnis/composer-normalize": "^2.28",
+                "ergebnis/phpunit-slow-test-detector": "^2.20",
+                "mantle-framework/cache": "^1.16",
+                "mantle-framework/config": "^1.16",
+                "mantle-framework/container": "^1.16",
+                "mantle-framework/contracts": "^1.16",
+                "mantle-framework/database": "^1.16",
+                "mantle-framework/events": "^1.16",
+                "mantle-framework/faker": "^1.15",
+                "mantle-framework/filesystem": "^1.16",
+                "mantle-framework/framework-views": "^1.16",
+                "mantle-framework/http": "^1.16",
+                "mantle-framework/http-client": "^1.16",
+                "mantle-framework/support": "^1.16",
+                "mantle-framework/testing": "^1.16",
+                "mantle-framework/testkit": "^1.16",
+                "mantle-framework/view": "^1.16",
                 "php-parallel-lint/php-parallel-lint": "^1.3",
                 "php-stubs/wp-cli-stubs": "^2.0",
                 "phpro/grumphp": "^2.0",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^2",
-                "phpunit/phpunit": "^9.0",
+                "phpunit/phpunit": "^11.5 || ^12",
                 "rector/rector": "^2.0",
                 "squizlabs/php_codesniffer": "^3.0",
-                "symplify/easy-coding-standard": "^12",
+                "symplify/easy-coding-standard": "^13",
                 "szepeviktor/phpstan-wordpress": "^2",
                 "twig/cache-extra": "^3.17",
-                "wpackagist-plugin/advanced-custom-fields": "^6.0",
-                "wpackagist-plugin/co-authors-plus": "^3.6",
-                "yoast/wp-test-utils": "^1.2"
+                "wp-plugin/advanced-custom-fields": "^6.5",
+                "wp-plugin/co-authors-plus": "^3.6"
             },
             "suggest": {
                 "php-coveralls/php-coveralls": "^2.0 for code coverage",
@@ -922,7 +938,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2025-09-24T14:07:33+00:00"
+            "time": "2026-04-20T08:31:34+00:00"
         },
         {
             "name": "twig/twig",


### PR DESCRIPTION
# Summary

This PR updates Timber to the latest version, which includes the dependabot update to twig.

## Issues

* N/A

## Testing Instructions

1. Installer should use Timber 2.4.* and Twig 3.26.*

