### PR TITLE
Fix editor/scoped styles missing editor-only CSS

### DIFF
--- a/wp-content/themes/wp-starter/inc/class-vite.php
+++ b/wp-content/themes/wp-starter/inc/class-vite.php
@@ -19,9 +19,9 @@ namespace WPStarter;
  * | editor  | editor.js   | enqueue_block_editor_assets  |
  *
  * The editor entry imports virtual:editor-scoped-styles, which the
- * vite-scoped-editor-styles Vite plugin uses to inject CSS scoped to
- * .editor-styles-wrapper — replicating add_editor_style() in both
- * dev (with HMR) and prod.
+ * vite-scoped-editor-styles Vite plugin uses to inject editor.css
+ * (main styles + editor-only sheets) scoped to .editor-styles-wrapper —
+ * replicating add_editor_style() in both dev (with HMR) and prod.
  *
  * ## Entry mirroring for add_css_dependency(), add_js_dependency(), localize_vars()
  *

--- a/wp-content/themes/wp-starter/src/editor.js
+++ b/wp-content/themes/wp-starter/src/editor.js
@@ -1,8 +1,5 @@
 // Import main script
 import './_main.js';
 
-// Import editor styles
-import './styles/editor.css';
-
 // Customized styles for the block editor (inline and iframe)
 import 'virtual:editor-scoped-styles';

--- a/wp-content/themes/wp-starter/src/plugins/vite-scoped-editor-styles.js
+++ b/wp-content/themes/wp-starter/src/plugins/vite-scoped-editor-styles.js
@@ -1,8 +1,9 @@
 /**
  * Vite plugin: virtual:editor-scoped-styles
  *
- * Imported by editor.js. Runs the full PostCSS pipeline on src/styles/main.css
- * and returns a JS module that:
+ * Imported by editor.js. Runs the full PostCSS pipeline on the configured
+ * cssEntry (typically src/styles/editor.css, which imports main.css plus
+ * editor-only sheets) and returns a JS module that:
  *   - Injects scoped CSS into the parent admin document (non-iframe editor).
  *     Only `body` and bare element selectors (h1, p, ul …) are prefixed with
  *     `.editor-styles-wrapper` — mirroring WordPress's transformStyles() logic.
@@ -10,6 +11,11 @@
  *   - Injects unscoped CSS directly into the Gutenberg editor iframe (no
  *     prefix needed inside the iframe).
  *   - Copies cross-origin font <link> tags into the iframe.
+ *
+ * Nested @import-glob: postcss-import-ext-glob only expands globs in the file
+ * it processes. Before Tailwind runs, we recursively inline local @imports
+ * whose targets still contain @import-glob (e.g. editor.css → main.css) so
+ * those globs expand relative to the imported file.
  *
  * HMR: handleHotUpdate() explicitly invalidates the virtual module and returns
  * [mod] so Vite pushes an update to the browser on every CSS change.  Relying
@@ -224,10 +230,55 @@ export default function viteEditorStyles(options = {}) {
 		return cssProcessor;
 	}
 
+	/**
+	 * Expand @import-glob in `css`, then replace local @imports that still
+	 * contain @import-glob with their glob-expanded contents (recursively).
+	 * Leaves package / URL imports and plain CSS @imports for Tailwind.
+	 */
+	async function expandNestedImportGlobs(css, from, seen = new Set()) {
+		const { default: postcssImportExtGlob } = await import('postcss-import-ext-glob');
+		const expanded = (await postcss([postcssImportExtGlob()]).process(css, { from })).css;
+		const importRe = /@import\s+(?:url\(\s*)?['"]([^'"\n]+)['"]\s*\)?\s*;/g;
+
+		let output = '';
+		let lastIndex = 0;
+
+		for (const match of expanded.matchAll(importRe)) {
+			output += expanded.slice(lastIndex, match.index);
+			lastIndex = match.index + match[0].length;
+
+			const rel = match[1];
+			if (!rel.startsWith('.')) {
+				output += match[0];
+				continue;
+			}
+
+			const abs = path.resolve(path.dirname(from), rel);
+			if (!existsSync(abs) || seen.has(abs)) {
+				output += match[0];
+				continue;
+			}
+
+			const child = readFileSync(abs, 'utf-8');
+			if (!child.includes('@import-glob')) {
+				output += match[0];
+				continue;
+			}
+
+			seen.add(abs);
+			output += await expandNestedImportGlobs(child, abs, seen);
+			output += '\n';
+		}
+
+		output += expanded.slice(lastIndex);
+		return output;
+	}
+
 	async function buildCssVariants(cssEntryPath) {
 		const rawCss = readFileSync(cssEntryPath, 'utf-8');
+		const flattenedCss = await expandNestedImportGlobs(rawCss, cssEntryPath);
 		const processor = await getCssProcessor();
-		const result = await processor.process(rawCss, { from: cssEntryPath });
+		const result = await processor.process(flattenedCss, { from: cssEntryPath });
 		const unscopedCss = result.css;
 
 		const deps = new Set(

--- a/wp-content/themes/wp-starter/vite.config.js
+++ b/wp-content/themes/wp-starter/vite.config.js
@@ -24,7 +24,7 @@ export default defineConfig(({ command }) => ({
 			],
 		}),
 		viteEditorStyles({
-			cssEntry: path.resolve(__dirname, 'src/styles/main.css'),
+			cssEntry: path.resolve(__dirname, 'src/styles/editor.css'),
 			watchPaths: [
 				path.resolve(__dirname, './src/**/*.css'),
 				path.resolve(__dirname, './blocks/**/*.css'),


### PR DESCRIPTION
## Summary

- `virtual:editor-scoped-styles` ran its PostCSS pipeline against `src/styles/main.css` directly, so editor-only styles (`styles/editor/*.css`, `blocks/**/editor.css` — pulled in via `src/styles/editor.css`) never went through the scoping transform. `editor.js` worked around this with a second, unscoped `import './styles/editor.css'` — which duplicated `main.css`'s output *unscoped* alongside the properly-scoped version, rather than fixing the actual gap.
- Points `cssEntry` at `editor.css` (which imports `main.css` plus the editor-only sheets) instead of `main.css` directly, and removes the redundant unscoped import from `editor.js`.
- That surfaced a second bug: `postcss-import-ext-glob` only expands `@import-glob` in the file it's directly given. `editor.css`'s own `@import-glob` lines expanded fine, but `main.css`'s `@import-glob` lines did **not** expand when `main.css` was merely `@import`ed by `editor.css` rather than processed directly. Added `expandNestedImportGlobs()` to recursively inline local `@import`s whose target still contains `@import-glob` before Tailwind runs, so nested `@import-glob` chains resolve regardless of which file is the actual `cssEntry`.

## Why

Without this, any CSS placed under `styles/editor/*.css` or a block's `editor.css` for editor-only styling was silently dropped from the scoped-styles pipeline — it would only reach the editor if it happened to also be reachable from `main.css`, and even then arrived unscoped.

## Test plan

- [x] `ddev npm run build` — builds clean.
- [x] Confirmed the editor entry no longer emits a separate (redundant, unscoped) editor CSS asset in the manifest — scoped editor styles are now injected entirely through the virtual module as intended.
- [x] Diffed the applied changes byte-for-byte against the original fix (see below) to confirm a clean, mechanical port.
- [ ] Reviewer: load the block editor and confirm editor-only styles (anything under `styles/editor/*.css` or a block's `editor.css`) still render correctly, scoped to `.editor-styles-wrapper`.

Backported from a client project scaffolded from this template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
