### PR TITLE
Hide Fonts, Menus, and Widgets from the Appearance menu

### DIFF
--- a/wp-content/mu-plugins/viget-wp/src/classes/Admin/Menu.php
+++ b/wp-content/mu-plugins/viget-wp/src/classes/Admin/Menu.php
@@ -13,6 +13,35 @@ class Menu {
 	public function __construct() {
 		// Customize the Admin Menu
 		$this->customize_menus();
+
+		// Hide the Appearance items the Site Editor replaces
+		$this->remove_appearance_items();
+	}
+
+	/**
+	 * Remove Appearance Submenu Items
+	 *
+	 * @return void
+	 */
+	private function remove_appearance_items(): void {
+		add_filter(
+			'vigetwp_admin_menu',
+			function ( array $mods ): array {
+				if ( ! wp_is_block_theme() ) {
+					return $mods;
+				}
+
+				foreach ( [ 'font-library.php', 'nav-menus.php', 'widgets.php' ] as $submenu ) {
+					$mods[] = [
+						'menu'    => 'themes.php',
+						'submenu' => $submenu,
+						'remove'  => true,
+					];
+				}
+
+				return $mods;
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
# Summary

On a block theme the Site Editor already covers Fonts (Styles → Typography), Menus (Navigation block), and Widgets (template parts), but all three still show up under **Appearance**. This removes them via the existing `vigetwp_admin_menu` filter in `Admin\Menu`.

Fonts is added unconditionally by core (`wp-admin/menu.php`), so it has always been visible.

Menus and Widgets are less obvious: any plugin calling `register_sidebar()` gets `add_theme_support( 'widgets' )` for free (`wp-includes/widgets.php:318`), and `wp-admin/menu.php:250` adds **Menus** whenever the theme supports `menus` *or* `widgets` — with no block-theme guard. So a single plugin registering a widget area puts both items back on a block theme. This surfaced on a client project when SearchWP 4.6.0 started registering sidebars for its Results Templates.

## Changes

* `Admin\Menu::remove_appearance_items()` appends three `remove` entries (`font-library.php`, `nav-menus.php`, `widgets.php`) to the `vigetwp_admin_menu` filter.
* Guarded by `wp_is_block_theme()` so a classic-theme project keeps its Menus and Widgets screens.

Reuses the existing filter and its `remove` branch rather than adding new removal code, so a project can still adjust the list through `vigetwp_admin_menu`.

## Notes

This only hides the menu items; the screens remain reachable by direct URL, matching how the other `vigetwp_admin_menu` removals in this plugin behave.

## Testing Instructions

1. On a block theme, load wp-admin and confirm **Appearance** shows only Themes, Editor, and any plugin-added items — no Fonts, Menus, or Widgets.
2. Activate a plugin that registers a widget area (or call `register_sidebar()` in a snippet) and confirm Menus/Widgets still do not reappear.
3. Switch to a classic theme and confirm Menus and Widgets are back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu3q6V279JN9ixvtpdfTeN