### PR TITLE
[N/A] Update Viget Blocks Toolkit to 1.1.8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ Child blocks (nested inside a parent) always have `"parent": ["acf/<parent-slug>
 - Common `supports.layout` types: `"constrained"`, `"grid"`, `"flex"`.
 - Add `"color": { "background": true }` under `supports` when background color switching is needed.
 - Add `"spacing": { "padding": ["top","bottom"] }` under `supports` when padding control is needed.
+- Add `"autoId": true` under `supports` only when the block needs a generated html `id` on its wrapper (in-page anchor target, scoped styles). Defaults to `false` as of Viget Blocks Toolkit 1.1.8 — before that every block got one automatically. This is unrelated to core's `anchor` support, which renders an editor-typed id and needs no declaration.
 - Add `"styles": [...]` for block style variations (like dismissible/default).
 - Grid parent blocks (e.g. card containers): use `"type": "grid"` layout with `"columnCount"` and `"minimumColumnWidth": null`.
 - For a real-world reference of supports/attributes, see [`blocks/alert-banner/block.json`](wp-content/themes/wp-starter/blocks/alert-banner/block.json) and [`blocks/cta/block.json`](wp-content/themes/wp-starter/blocks/cta/block.json).
@@ -460,7 +461,7 @@ These global helpers are registered in the theme — use them freely:
 
 - `block_attrs( $block, $class = '', $attrs = [] )` — outputs all block wrapper attributes.
 - `inner_blocks( $args )` — outputs ACF inner blocks; accepts `template`, `allowedBlocks`, `templateLock`.
-- `get_block_id( $block )` — returns a unique ID for the block instance.
+- `get_block_id( $block )` — returns a unique ID for the block instance. Note this returns a value whether or not the block declares `supports.autoId`; the support controls only whether `block_attrs()` renders it as an html `id`.
 
 Project-specific helpers (singletons, taxonomy accessors, icon registries, etc.) are not assumed by this guide — discover them by reading existing blocks in the active theme.
 
@@ -548,5 +549,6 @@ Do not invent API surfaces. If you're not sure, fetch and cite, or ask the devel
 - PHP files use `// phpcs:ignore` comments on lines that intentionally break PHPCS rules (like inline array assignments in render.php).
 - For Alpine.js: `x-data`, `x-show`, etc. go in `$attrs` array in `render.php` and are only applied when `! is_admin()`.
 - `$persist()` is available for Alpine.js persistent state (used in alert-banner).
+- Blocks do not render an html `id` by default. If markup or JS needs to reference the wrapper by id, either declare `"supports": { "autoId": true }` or pass one explicitly: `block_attrs( $block, '', [ 'id' => $id ] )` — see [`blocks/alert-banner/render.php`](wp-content/themes/wp-starter/blocks/alert-banner/render.php). Prefer an Alpine `x-ref` over an id for scripting.
 - Child block `block.json` files must include `"parent": ["acf/<parent-slug>"]`.
 - Always add a dev fallback in `render.twig` for blocks that pull dynamic data (taxonomies, CPT queries) so the block looks good before real data exists.

--- a/wp-content/themes/wp-starter/composer.json
+++ b/wp-content/themes/wp-starter/composer.json
@@ -27,7 +27,7 @@
     "ext-json": "*",
     "idleberg/wordpress-vite-assets": "^1.2",
     "timber/timber": "^2.4",
-    "viget/viget-blocks-toolkit": "^1.1",
+    "viget/viget-blocks-toolkit": "^1.1.8",
     "wpackagist-plugin/accessibility-checker": "^1.42",
     "wpackagist-plugin/safe-svg": "^2.4",
     "wpackagist-plugin/seo-by-rank-math": "^1.0",

--- a/wp-content/themes/wp-starter/composer.lock
+++ b/wp-content/themes/wp-starter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a2d6017734105593317daaa0258c2d5",
+    "content-hash": "9b3251cb713da45a95a46b29b1db31a1",
     "packages": [
         {
             "name": "composer/installers",
@@ -1021,16 +1021,16 @@
         },
         {
             "name": "viget/viget-blocks-toolkit",
-            "version": "v1.1.5",
+            "version": "v1.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vigetlabs/viget-blocks-toolkit.git",
-                "reference": "4bf3652fb267c03c54a55dc9aa28ef1d32a59be7"
+                "reference": "548ed20b41a949fd333ee76ea13ebf44fa3862d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vigetlabs/viget-blocks-toolkit/zipball/4bf3652fb267c03c54a55dc9aa28ef1d32a59be7",
-                "reference": "4bf3652fb267c03c54a55dc9aa28ef1d32a59be7",
+                "url": "https://api.github.com/repos/vigetlabs/viget-blocks-toolkit/zipball/548ed20b41a949fd333ee76ea13ebf44fa3862d8",
+                "reference": "548ed20b41a949fd333ee76ea13ebf44fa3862d8",
                 "shasum": ""
             },
             "require": {
@@ -1060,9 +1060,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vigetlabs/viget-blocks-toolkit/issues",
-                "source": "https://github.com/vigetlabs/viget-blocks-toolkit/tree/v1.1.5"
+                "source": "https://github.com/vigetlabs/viget-blocks-toolkit/tree/v1.1.8"
             },
-            "time": "2026-03-25T23:55:41+00:00"
+            "time": "2026-08-31T02:32:47+00:00"
         },
         {
             "name": "wpackagist-plugin/accessibility-checker",
@@ -1828,5 +1828,5 @@
         "ext-json": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
# Summary

Moves the theme from Viget Blocks Toolkit **v1.1.5 → v1.1.8** and raises the constraint from `^1.1` to `^1.1.8`.

The constraint bump matters: a `1.1.7` was published to Packagist from an earlier commit and, because Packagist stable versions are immutable, it can never be corrected. `^1.1.8` pins safely past it.

## The `autoId` change

1.1.8 makes the generated html `id` on block wrappers **opt-in** via `supports.autoId`. Previously every block got one automatically. I audited all seven `block_attrs()` call sites in the theme:

| Block | How it renders | Affected? |
|---|---|---|
| `alert-banner` | passes `$attrs['id']` explicitly | No — explicit ids always render |
| `video-player` | no id; Alpine `x-data` only | No |
| `navigation-container` | no id; Alpine `x-data`/`x-trap` only | No |
| `image-caption` | `block_attrs( $block )` | No |
| `text-icon-card` | `block_attrs( $block )` | No |
| `breadcrumbs` | `block_attrs( $block )` | No |
| `dialog` (PR #162) | targets `x-ref="dialogRef"` | No |

Also checked: no theme CSS, JS, or a11y attribute (`aria-controls`, `aria-labelledby`, `for=`) resolves a block wrapper by id, and nothing reads the editor-side `data-id`.

**Conclusion: no block in the theme needs `autoId`, so none were changed.** Alert banner and dialog specifically were the two suspected of needing it — alert banner already passes its id explicitly, and dialog uses an Alpine ref.

## Documentation

`AGENTS.md` drives AI block scaffolding, so it needed to know the id is now opt-in — otherwise generated blocks could assume a wrapper id exists. Added:

* a `supports.autoId` entry in the `block.json` conventions,
* a note on `get_block_id()` clarifying it still returns a value regardless of the support,
* a gotcha steering new blocks toward `x-ref` or an explicit id.

## Note for existing client sites

Sites already built from this starter that relied on the old always-on ids can restore the previous behavior globally:

```php
add_filter( 'vgtbt_default_auto_id', '__return_true' );
```

## Issues

* N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJqeN94iGhbU67LzA2iNga